### PR TITLE
example icon svg code has wrong class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can paste the content of the icon file into your HTML code to display it on 
 ```html
 <a href="">
   <svg xmlns="http://www.w3.org/2000/svg" 
-    class="icon tabler-icon tabler-icon-disabled" 
+    class="icon icon-tabler icon-tabler-disabled" 
     width="24" height="24" viewBox="0 0 24 24" 
     stroke-width="1.25" stroke="currentColor" fill="none" 
     stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
This pull requests changes the class names in the readme example to match the class names of the actual icons