### PR TITLE
Publish tabler-icons as @tabler/icons on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A set of over 850 free MIT-licensed high-quality SVG icons for you to use in you
 ## Installation
 
 ```
-npm install tabler-icons --save
+npm install @tabler/icons --save
 ```
 
 or just [download from Github](https://github.com/tabler/tabler-icons/releases).
@@ -78,7 +78,7 @@ Add an icon to be displayed on your page with the following markup (`activity` i
 Import the icon and render it in your component. You can adjust SVG properties through React props:
 
 ```jsx
-import { IconAward } from 'tabler-icons';
+import { IconAward } from '@tabler/icons';
 
 const MyComponent = () => {
   return <IconAward 
@@ -90,7 +90,7 @@ const MyComponent = () => {
 }
 ```
 
-`tabler-icons` exports it's own type declarations for usage with React and Typescript.
+`@tabler/icons` exports it's own type declarations for usage with React and Typescript.
 
 ## Multiple strokes
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "tabler-sprite.svg",
     "tabler-sprite-nostroke.svg"
   ],
+  "publishConfig": {
+    "access": "public"   
+  },
   "homepage": "https://github.com/tabler/tabler-icons#readme",
   "scripts": {
     "start": "bundle exec jekyll serve --watch --livereload --trace --livereload_port 8888",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tabler-icons",
+  "name": "@tabler/icons",
   "version": "1.35.0",
   "repository": {
     "type": "git",
@@ -9,7 +9,8 @@
   "module": "./icons-react/dist/index.esm.js",
   "browser": "./icons-react/dist/index.umd.js",
   "types": "./icons-react/index.d.ts",
-  "author": "",
+  "sideEffects": false,
+  "author": "codecalm",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tabler/tabler-icons/issues"
@@ -35,7 +36,16 @@
     "optimize": "gulp optimize",
     "release": "release-it"
   },
-  "description": "",
+  "description": "A set of free MIT-licensed high-quality SVG icons for you to use in your web projects.",
+  "keywords": [
+    "icons",
+    "svg",
+    "png",
+    "iconfont",
+    "react",
+    "front-end",
+    "web"
+  ],
   "devDependencies": {
     "@babel/core": "7.11.6",
     "@babel/parser": "7.11.5",


### PR DESCRIPTION
After merging we need to deprecate old package with appropriate message that will redirect users to new package.
https://docs.npmjs.com/cli/v6/commands/npm-deprecate

Old package: https://www.npmjs.com/package/tabler-icons
New package: https://www.npmjs.com/package/@tabler/icons