### PR TITLE
Mention tabler-icons-svelte in readme usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ To load a specific version replace `latest` with the desired version number.
 <script src="https://unpkg.com/@tabler/icons@1.36.0/icons-react/dist/index.umd.js"></script>
 ```
 
+### Svelte
+
+You can use [`tabler-icons-svelte`](https://github.com/benflap/tabler-icons-svelte) to use icons in your Svelte projects (see [example](https://svelte.dev/repl/e80dc63d7019431692b10a77525e7f99?version=3.31.0)):
+
+```js
+<script>
+    import { CurrencyBitcoin, BrandGithub, CircleX } from "tabler-icons-svelte";
+</script>
+
+<CurrencyBitcoin />
+<BrandGithub size="48" strokeWidth="1" />
+<CircleX />
+```
+
 ## Multiple strokes
 
 All icons in this repository have been created with the value of the `stroke-width` property, so if you change the value, you can get different icon variants that will fit in well with your design.


### PR DESCRIPTION
I just learned about this project through [tabler-icons-svelte](https://github.com/benflap/tabler-icons-svelte), and I really like the icons. Thanks a lot for your work.

If you agree that it's worth explaining how to use tabler-icons in [Svelte](https://svelte.dev/), here's a PR for you. :)