### PR TITLE
Update package exports and peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     }
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.x || 17.x",
+    "react-dom": "^16.x || 17.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "url": "git+https://github.com/tabler/tabler-icons.git"
   },
   "main": "./icons-react/dist/index.cjs.js",
+  "exports": "./icons-react/dist/index.esm.js",
   "module": "./icons-react/dist/index.esm.js",
-  "browser": "./icons-react/dist/index.umd.js",
+  "unpkg": "./icons-react/dist/index.umd.js",
+  "umd:main": "./icons-react/dist/index.umd.js",
   "types": "./icons-react/index.d.ts",
   "sideEffects": false,
   "author": "codecalm",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -83,7 +83,7 @@ export default [
   {
     input,
     output: {
-      file: minifyExtension(pkg.browser),
+      file: minifyExtension(pkg['umd:main']),
       format: "umd",
       sourcemap: true,
       name: "tablerIcons",


### PR DESCRIPTION
This PR updates the main et.al. fields to point to the correct dist files as discussed in #113. It also updates the react peer dependencies to be a bit looser than before, as discussed in #115.

Hope you don't mind that I took the liberty of providing this PR, I know managing a popular OSS library can be cumbersome. I would like you to know that I really appreciate the work and love the quality of the icons!

Closes #113
Closes #115