### PR TITLE
Make it easier to compile a font with sub set of icons

### DIFF
--- a/.build/iconfont.scss
+++ b/.build/iconfont.scss
@@ -40,9 +40,12 @@ $ti-prefix: 'ti' !default;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+@function unicode($str) {
+  @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\"")
+}
 
 <% glyphs.forEach(function(glyph) { %>
-$ti-icon-<%= glyph.name %>: '\<%= glyph.unicode[0].codePointAt(0).toString(16) %>';<% }); %>
+$ti-icon-<%= glyph.name %>: unicode('<%= glyph.unicode[0].codePointAt(0).toString(16) %>');<% }); %>
 
 <% glyphs.forEach(function(glyph) { %>
 .#{$ti-prefix}-<%= glyph.name %>:before { content: $ti-icon-<%= glyph.name %>; }<% }); %>

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/test*.svg
 .jekyll-metadata
 icons-react/dist/
 /_import.csv
+compile-options.json

--- a/README.md
+++ b/README.md
@@ -127,6 +127,35 @@ To load a specific version replace `latest` with the desired version number.
 <script src="https://unpkg.com/@tabler/icons@1.36.0/icons-react/dist/index.umd.js"></script>
 ```
 
+Compiling fonts:
+
+To compile fonts first install [fontforge](https://fontforge.org/en-US/)
+
+the fontforge executable needs to be in the path or you can set set the path to the downloaded fontforge executable in the package.json. If you installed in on a mac in your application directory it will be:
+```JSON
+  "compileFonts": {
+    "fontForge":"/Applications/FontForge.app/Contents/MacOS/FontForge"
+  }
+```
+To compile the fonts run:
+  npm run build-iconfont
+
+By default the stroke width is 2. You can change the stroke width by setting the package property: 
+
+```JSON
+  "compileFonts": {
+     "strokeWidth":"1.5",
+  }
+```
+
+To reduce the font file size you can choose to compile a sub set of icons. When you leave the array empty it will compile all the fonts. For example:
+
+```JSON
+  "includeIcons": {
+    "include":["alert-octagon","alert-triangle"]
+  }
+```  
+
 ### Svelte
 
 You can use [`tabler-icons-svelte`](https://github.com/benflap/tabler-icons-svelte) to use icons in your Svelte projects (see [example](https://svelte.dev/repl/e80dc63d7019431692b10a77525e7f99?version=3.31.0)):

--- a/README.md
+++ b/README.md
@@ -131,28 +131,38 @@ Compiling fonts:
 
 To compile fonts first install [fontforge](https://fontforge.org/en-US/)
 
-the fontforge executable needs to be in the path or you can set set the path to the downloaded fontforge executable in the package.json. If you installed in on a mac in your application directory it will be:
+When compiling the font it will look for a json file compile-options.json in root folder (same folder as the package.json) In this file you can define extra options:
+
+The default settings if you have not defined the file will be:
+{
+  "includeIcons": [],
+  "fontForge": "fontforge",
+  "strokeWidth": 2
+}
+
+The fontforge executable needs to be in the path or you can set set the path to the downloaded fontforge executable in the. If you installed in on a mac in your application directory it will be "/Applications/FontForge.app/Contents/MacOS/FontForge". You can set this value in the compile-options.json file.
+
 ```JSON
-  "compileFonts": {
+  {
     "fontForge":"/Applications/FontForge.app/Contents/MacOS/FontForge"
   }
 ```
 To compile the fonts run:
   npm run build-iconfont
 
-By default the stroke width is 2. You can change the stroke width by setting the package property: 
+By default the stroke width is 2. You can change the stroke width in the compile-options.json 
 
 ```JSON
-  "compileFonts": {
-     "strokeWidth":"1.5",
+  {
+     "strokeWidth": 1.5,
   }
 ```
 
-To reduce the font file size you can choose to compile a sub set of icons. When you leave the array empty it will compile all the fonts. For example:
+To reduce the font file size you can choose to compile a sub set of icons. When you leave the array empty it will compile all the fonts. To compile only two icons you can set for example the folowing option in the compile-options.json:
 
 ```JSON
-  "includeIcons": {
-    "include":["alert-octagon","alert-triangle"]
+  {
+    "includeIcons":["alert-octagon","alert-triangle"]
   }
 ```  
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,22 +27,26 @@ let compileOptions = {
 if (fs.existsSync('./compile-options.json')) {
 	try {
 		let tempOptions = require('./compile-options');
-		if (typeof tempOptions!="object") 
-		  throw "Compile options file does not contain an json object";
+		if (typeof tempOptions!="object") {
+			throw "Compile options file does not contain an json object";
+		}
 		 
 		if (typeof tempOptions.includeIcons!="undefined") {
-			if (!Array.isArray(tempOptions.includeIcons)) 
-			  throw "property inludeIcons is not an array";
+			if (!Array.isArray(tempOptions.includeIcons)) {
+				throw "property inludeIcons is not an array";
+			}
 			compileOptions.includeIcons= tempOptions.includeIcons;
 		}
 		if (typeof tempOptions.strokeWidth!="undefined") {
-			if (typeof tempOptions.strokeWidth!="string" && typeof tempOptions.strokeWidth!="number") 
-			  throw "property strokeWidth is not a string or number";	
+			if (typeof tempOptions.strokeWidth!="string" && typeof tempOptions.strokeWidth!="number") {
+				throw "property strokeWidth is not a string or number";	
+			}
 			compileOptions.strokeWidth=tempOptions.strokeWidth.toString();			
 		}
 		if (typeof tempOptions.fontForge!="undefined") {
-			if (typeof tempOptions.fontForge!="string") 
-			  throw "property fontForge is not a string";	
+			if (typeof tempOptions.fontForge!="string") {
+				throw "property fontForge is not a string";	
+			} 
 		  	compileOptions.fontForge=tempOptions.fontForge;
 		}
 		
@@ -252,8 +256,9 @@ gulp.task('iconfont-svg-outline', function (cb) {
 				strokedSVG = strokedSVG
 					.replace('width="24"', 'width="1000"')
 					.replace('height="24"', 'height="1000"');
-					if (compileOptions.strokeWidth)
-					   strokedSVG = strokedSVG.replace('stroke-width="2"', `stroke-width="${compileOptions.strokeWidth}"`);
+				if (compileOptions.strokeWidth) {
+					strokedSVG = strokedSVG.replace('stroke-width="2"', `stroke-width="${compileOptions.strokeWidth}"`);
+				}
 
 				await outlineStroke(strokedSVG, {
 					optCurve: false,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "optimize": "gulp optimize",
     "release": "release-it",
     "build": "gulp build",
-    "build-iconfont": "gulp build-iconfont"
+    "build-iconfont": "gulp build-iconfont",
+    "copy":"cp -r -n -v -f ./iconfont/fonts/* ../WebErgometer/WebApp/html/font"
   },
   "description": "A set of free MIT-licensed high-quality SVG icons for you to use in your web projects.",
   "keywords": [
@@ -101,10 +102,5 @@
   "peerDependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
-  },
-  "compileFonts": {
-    "include":[],
-    "strokeWidth":"2",
-    "fontForge":"fontforge"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "optimize": "gulp optimize",
     "release": "release-it",
     "build": "gulp build",
-    "build-iconfont": "gulp build-iconfont",
-    "copy":"cp -r -n -v -f ./iconfont/fonts/* ../WebErgometer/WebApp/html/font"
+    "build-iconfont": "gulp build-iconfont"
   },
   "description": "A set of free MIT-licensed high-quality SVG icons for you to use in your web projects.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "prebuild-react": "rm -rf ./icons-react/dist/",
     "build-react": "rollup -c",
     "optimize": "gulp optimize",
-    "release": "release-it"
+    "release": "release-it",
+    "build": "gulp build",
+    "build-iconfont": "gulp build-iconfont"
   },
   "description": "A set of free MIT-licensed high-quality SVG icons for you to use in your web projects.",
   "keywords": [
@@ -99,5 +101,10 @@
   "peerDependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
+  },
+  "compileFonts": {
+    "include":[],
+    "strokeWidth":"2",
+    "fontForge":"fontforge"
   }
 }


### PR DESCRIPTION
Thank you for your great icons set. The icon set has grown to a very large font set. The font file becomes now a bit too large. I make a small (backwards compatible) change to allow you to compile a sub set of icons into a font. I also updated the documentation on compiling fonts so other users will have to spend less time figuring out how it works. 