### PR TITLE
Corrected wrong encoded unicode characters in css

### DIFF
--- a/.build/iconfont.scss
+++ b/.build/iconfont.scss
@@ -40,9 +40,12 @@ $ti-prefix: 'ti' !default;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+@function unicode($str) {
+  @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\"")
+}
 
 <% glyphs.forEach(function(glyph) { %>
-$ti-icon-<%= glyph.name %>: '\<%= glyph.unicode[0].codePointAt(0).toString(16) %>';<% }); %>
+$ti-icon-<%= glyph.name %>: unicode('<%= glyph.unicode[0].codePointAt(0).toString(16) %>');<% }); %>
 
 <% glyphs.forEach(function(glyph) { %>
 .#{$ti-prefix}-<%= glyph.name %>:before { content: $ti-icon-<%= glyph.name %>; }<% }); %>


### PR DESCRIPTION
The icon font css files contain al lot of wrong encoded characters. it should be unicoded like this:

.ti-cardboards:before {
  content: "\ed43";
}

This encoding is a problem in the sass compiler. I fixed this by applying an work around