### PR TITLE
Resolve TablerIconProps interface extends type error

### DIFF
--- a/icons-react/index.d.ts
+++ b/icons-react/index.d.ts
@@ -1,6 +1,7 @@
 import { FC, SVGAttributes } from 'react';
 
-interface TablerIconProps extends SVGAttributes<SVGElement> { color?: string; size?: string | number; stroke?: string | number; }
+type ExcludeStrokeType<T> = Pick<T, Exclude<keyof T, 'stroke'>>;
+interface TablerIconProps extends ExcludeStrokeType<SVGAttributes<SVGElement>> { color?: string; size?: string | number; stroke?: string | number; }
 
 type TablerIcon = FC<TablerIconProps>;
 


### PR DESCRIPTION
resolve conflict between `TablerIconProps` interface and the **stroke** property on `SVGAttributes`.

Changes remove the **stroke** property from the extends method so there is no conflict between types.

---

https://github.com/tabler/tabler-icons/blob/5235090dae2d37af873376e736aab39bc773bd5b/icons-react/index.d.ts#L3

This line above causes the following error:
```
Interface 'TablerIconProps' incorrectly extends interface 'SVGAttributes<SVGElement>'. Types of property 'stroke' are incompatible.
```

---

open to suggestions of implementing a different fix if needed.