### PR TITLE
Change 'food' to 'Food' for paper-bag's category

### DIFF
--- a/src/_icons/paper-bag.svg
+++ b/src/_icons/paper-bag.svg
@@ -1,5 +1,5 @@
 ---
-category: food
+category: Food
 version: "1.55"
 ---
 <svg>


### PR DESCRIPTION
I noticed there were multiple "food" category options on the documentation site (screenshot below). This was because `paper-bag` had a category of "food" (lowercase) while the other icons had a category of "Food" (uppercase).

<img width="163" alt="Screen Shot 2022-03-27 at 1 27 02 PM" src="https://user-images.githubusercontent.com/26150050/160295322-0440de8a-4e14-4075-921a-5809b9491b6d.png">
