### PR TITLE
package.json: export .svg and .png assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   },
   "main": "./icons-react/dist/index.cjs.js",
   "exports": {
-    "import": "./icons-react/dist/index.esm.js",
-    "require": "./icons-react/dist/index.cjs.js"
+    ".": {
+      "import": "./icons-react/dist/index.esm.js",
+      "require": "./icons-react/dist/index.cjs.js"
+    },
+    "./*": ["./icons/*", "./icons-png/*"]
   },
   "module": "./icons-react/dist/index.esm.js",
   "unpkg": "./icons-react/dist/index.umd.js",


### PR DESCRIPTION
For a while, I've been using Webpack alias hacks to directly import the `.svg` files from Tabler. I decided to finally solve it.

By changing the package.json exports, we can allow:

- `require('@tabler/icons/settings.svg')`
- `require('@tabler/icons/settings.png')`

The existing behavior (importing React components) still works fine too.