### PR TITLE
docs: switch cdns from unpkg to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,19 +191,19 @@ All files included in `@tabler/icons` npm package are available over a CDN.
 #### React icons
 
 ```html
-<script src="https://unpkg.com/@tabler/icons@latest/icons-react/dist/index.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tabler/icons@latest/icons-react/dist/index.umd.min.js"></script>
 ```
 
 #### Iconfont
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@tabler/icons@latest/iconfont/tabler-icons.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons@latest/iconfont/tabler-icons.min.css">
 ```
 
 To load a specific version replace `latest` with the desired version number.
 
 ```html
-<script src="https://unpkg.com/@tabler/icons@1.36.0/icons-react/dist/index.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tabler/icons@1.74.0/icons-react/dist/index.umd.min.js"></script>
 ```
 
 ### Compiling fonts


### PR DESCRIPTION
unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic).

Using the `latest` tag on unpkg also adds an additional redirect due to their implementation, which adds more latency.

If you're fine with this change, would you want me to make similar changes to the [tabler/tabler](https://github.com/tabler/tabler) main repository? I'd be happy to make a PR there too.