### PR TITLE
Fix `TablerIconProps` type definition

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -662,7 +662,7 @@ gulp.task('svg-to-react', gulp.series('clean-react', async (cb) => {
   }
 
   let indexCode = '',
-      indexDCode = `import { FC, SVGAttributes } from 'react';\n\ninterface TablerIconProps extends SVGAttributes<SVGElement> { color?: string; size?: string | number; stroke?: string | number; }\n\ntype TablerIcon = FC<TablerIconProps>;\n\n`
+      indexDCode = `import { FC, SVGAttributes } from 'react';\n\ntype TablerIconProps = Omit<SVGAttributes<SVGElement>, 'color' | 'stroke'> & {\n  color?: SVGAttributes<SVGElement>['stroke'];\n  size?: SVGAttributes<SVGElement>['width'];\n  stroke?: SVGAttributes<SVGElement>['strokeWidth'];\n}\n\ntype TablerIcon = FC<TablerIconProps>;\n\n`
 
   await asyncForEach(files, async function(file) {
     const svgCode = optimizeSvgCode(fs.readFileSync(file).toString()),

--- a/icons-react/index.d.ts
+++ b/icons-react/index.d.ts
@@ -1,6 +1,10 @@
 import { FC, SVGAttributes } from 'react';
 
-interface TablerIconProps extends SVGAttributes<SVGElement> { color?: string; size?: string | number; stroke?: string | number; }
+type TablerIconProps = Omit<SVGAttributes<SVGElement>, 'color' | 'stroke'> & {
+  color?: SVGAttributes<SVGElement>['stroke'];
+  size?: SVGAttributes<SVGElement>['width'];
+  stroke?: SVGAttributes<SVGElement>['strokeWidth'];
+}
 
 type TablerIcon = FC<TablerIconProps>;
 


### PR DESCRIPTION
Fixes #294

Extending an interface implies that a value of the subtype can be assigned to the supertype, but `TablerIconProps` can't be assigned to `SVGAttributes<SVGElement>` because the `stroke` property is incompatible (because it is actually used to set the `strokeWidth`).

Instead, this PR uses [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) to remove the overridden properties from the base type and adds them to the props by referencing the type of the SVG attributes that they ultimately are used to set. This approach has the advantage of guaranteeing that these property types are consistent with React (in particular, they explicitly allow `undefined`, which is needed with [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)).