### PR TITLE
Export iconfont module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "import": "./icons-react/dist/index.esm.js",
       "require": "./icons-react/dist/index.cjs.js"
     },
+    "./iconfont/*": "./iconfont/*",
     "./*": [
       "./icons/*",
       "./icons-png/*"


### PR DESCRIPTION
This pull request adds the `iconfont` module export, allowing to import the css files.

This fixes #210.