### PR TITLE
Renamed ESM files to .mjs instead of .js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./icons-react/dist/index.cjs.js",
   "exports": {
     ".": {
-      "import": "./icons-react/dist/index.esm.js",
+      "import": "./icons-react/dist/index.esm.mjs",
       "require": "./icons-react/dist/index.cjs.js"
     },
     "./iconfont/*": "./iconfont/*",
@@ -18,7 +18,7 @@
       "./icons-png/*"
     ]
   },
-  "module": "./icons-react/dist/index.esm.js",
+  "module": "./icons-react/dist/index.esm.mjs",
   "unpkg": "./icons-react/dist/index.umd.js",
   "umd:main": "./icons-react/dist/index.umd.js",
   "types": "./icons-react/index.d.ts",


### PR DESCRIPTION
Hey there. We are using `@tabler/icons` as a dependency of a dependency.

The setup:

- `some-lib using @tabler/icons@latest`
- `some-lib` importing icons via ESM 
- Our `nextjs` package using `some-lib` 

Now there are apparently libraries such as NextJS that have problems detecting sub-dependencies correctly when the imported ESM files aren't named `.mjs`.

Surely there is work to do on those libraries (being discussed as well here:  https://github.com/vercel/next.js/issues/39375#issuecomment-1380266233) but since `.mjs` is a very common format for `ESM`, also being used in my own packages such as https://github.com/activenode/react-use-focus-trap/blob/main/package.json#L35 I am herewith recommending the change for the ESM files from `.js` to `.mjs` with a Pull Request with only positive impact IMO.

If you have any questions please go ahead.


Sources:
- https://yarnpkg.com/configuration/manifest#module
- https://www.typescriptlang.org/docs/handbook/esm-node.html 
- https://github.com/vercel/next.js/issues/39375#issuecomment-1380443503 