### PR TITLE
Fix `TablerIconsProps` type definition

### DIFF
--- a/packages/icons-react/build.mjs
+++ b/packages/icons-react/build.mjs
@@ -21,7 +21,7 @@ import { SVGAttributes } from 'react'
 declare module '@tabler/icons-react'
 
 // Create interface extending SVGProps
-export interface TablerIconsProps extends Partial<React.SVGProps<SVGSVGElement>> {
+export interface TablerIconsProps extends Partial<Omit<React.SVGProps<SVGSVGElement>, 'stroke'>> {
     size?: string | number,
     stroke?: string | number
 }


### PR DESCRIPTION
Looks like https://github.com/tabler/tabler-icons/issues/294 was reintroduced - this should fix it again.