### PR TITLE
fix: `getCompileOptions` path inconsistencies

### DIFF
--- a/.build/helpers.mjs
+++ b/.build/helpers.mjs
@@ -274,16 +274,21 @@ export const printChangelog = function(newIcons, modifiedIcons, renamedIcons, pr
 }
 
 
-export const getCompileOptions = () => {
+export const getCompileOptions = async () => {
   const compileOptions = {
     includeIcons: [],
     strokeWidth: null,
     fontForge: 'fontforge'
   }
 
-  if (fs.existsSync('../compile-options.json')) {
+  // Check if the `compile-options.json` file exists,
+  // `fs.existsSync` uses the current working directory for relative paths,
+  // therefore we first need to resolve the absolute path using our parent directory.
+  // (Otherwise `import` and `fs.existsSync` could use different paths)
+  const absolutePath = path.resolve(__dirname, '../compile-options.json')
+  if (fs.existsSync(absolutePath)) {
     try {
-      const tempOptions = require('../compile-options.json')
+      const tempOptions = await import('../compile-options.json')
 
       if (typeof tempOptions !== 'object') {
         throw 'Compile options file does not contain an json object'

--- a/README.md
+++ b/README.md
@@ -253,13 +253,13 @@ The fontforge executable needs to be in the path or you can set the path to the 
 
 To compile the fonts run:
 ```sh
-npm run build-iconfont
+npm run build:webfont
 ```
 
 By default the stroke width is 2. You can change the stroke width in the `compile-options.json`
 ```JSON
 {
-  "strokeWidth": 1.5,
+  "strokeWidth": 1.5
 }
 ```
 

--- a/packages/icons-webfont/.build/build-outline.mjs
+++ b/packages/icons-webfont/.build/build-outline.mjs
@@ -7,7 +7,7 @@ const DIR = getPackageDir('icons-webfont')
 
 const buildOutline = async () => {
   let files = readSvgs()
-  const compileOptions = getCompileOptions()
+  const compileOptions = await getCompileOptions()
 
   const iconfontUnicode = JSON.parse(fs.readFileSync(resolve(HOME_DIR, 'tags.json'), 'utf-8'))
 


### PR DESCRIPTION
This fixes path inconsistencies discovered while trying to generate fonts.

The first fix is that (like discussed in the comment) `fs.existsSync` now resolves the path to `compile-options.json` relative to the directory. This mimics the behavior `import`/`require`; previously, this would lead to a disconnect and unexpected results (#666).

This also replaces `require` with `import` and makes the `getCompileOptions` function async, as `require` is no longer available in `.mjs` files if node >= 14 is used. (Function still uses `.existsSync` as it is not deprecated)

As a drive-by, I have corrected the `npm run` command in the README.