### PR TITLE
Use `fs.readFileSync` + `JSON.parse` to read compile options

### DIFF
--- a/.build/helpers.mjs
+++ b/.build/helpers.mjs
@@ -283,7 +283,7 @@ export const getCompileOptions = () => {
 
   if (fs.existsSync('../compile-options.json')) {
     try {
-      const tempOptions = require('../compile-options.json')
+      const tempOptions = JSON.parse(fs.readFileSync('../compile-options.json').toString())
 
       if (typeof tempOptions !== 'object') {
         throw 'Compile options file does not contain an json object'


### PR DESCRIPTION
On my machine the `require` in `.build/helpers.mjs` fails. I'm not entirely sure why that is (perhaps I'm using a too recent nodejs?), but nevertheless (and please correct me if I'm wrong) I don't really see a point in loading this file through `require`. There's an `fs.existsSync` used in the very same function (so there shouldn't be a problem with using synchronous Node APIs), and the file we're loading is a JSON, so we might just as well load it through `fs.readFileSync` + `JSON.parse`.