### PR TITLE
readme: fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 npm install @tabler/icons --save
 ```
 
-or just [download from Github](https://github.com/tabler/tabler-icons/releases).
+or just [download from GitHub](https://github.com/tabler/tabler-icons/releases).
 
 ## Usage
 


### PR DESCRIPTION
The official name is spelled with a capital H.
Like in [Line 16](https://github.com/tabler/tabler-icons/blob/bb7aa7903fc52abbc8195d551613f873ccb7cc11/README.md?plain=1#L16).