### PR TITLE
Fix "construction" typo in tags

### DIFF
--- a/src/_icons/crane-off.svg
+++ b/src/_icons/crane-off.svg
@@ -1,6 +1,6 @@
 ---
 category: Vehicles
-tags: [consturction, building, machine, lifting]
+tags: [construction, building, machine, lifting]
 version: "1.65"
 unicode: "f109"
 ---

--- a/src/_icons/crane.svg
+++ b/src/_icons/crane.svg
@@ -1,5 +1,5 @@
 ---
-tags: [consturction, building, machine, lifting]
+tags: [construction, building, machine, lifting]
 category: Vehicles
 version: "1.41"
 unicode: "ef27"

--- a/src/_icons/hammer-off.svg
+++ b/src/_icons/hammer-off.svg
@@ -1,5 +1,5 @@
 ---
-tags: [tool, repair, building, consturction]
+tags: [tool, repair, building, construction]
 version: "1.66"
 unicode: "f13c"
 ---

--- a/src/_icons/hammer.svg
+++ b/src/_icons/hammer.svg
@@ -1,5 +1,5 @@
 ---
-tags: [tool, repair, building, consturction]
+tags: [tool, repair, building, construction]
 version: "1.47"
 unicode: "ef91"
 ---

--- a/src/_icons/wall.svg
+++ b/src/_icons/wall.svg
@@ -1,5 +1,5 @@
 ---
-tags: [brick, security, firewall, building, renovation, consturction]
+tags: [brick, security, firewall, building, renovation, construction]
 version: "1.45"
 unicode: "ef7a"
 ---


### PR DESCRIPTION
Change "consturction" =>"construction" in tags. Closes #351.