### PR TITLE
Added strokeWidth property to icons-vue SVGProps interface

### DIFF
--- a/packages/icons-vue/build.mjs
+++ b/packages/icons-vue/build.mjs
@@ -21,6 +21,7 @@ declare module '@tabler/icons-vue'
 // Create interface extending SVGAttributes
 export interface SVGProps extends Partial<SVGAttributes> {
   size?: 24 | number
+  strokeWidth?: number | string
 }
 
 // Generated icons`


### PR DESCRIPTION
Fix for issue #758

When adjusting strokeWidth (f.e.  `<IconHome stroke-width="2" />`) now TS **won't** show the following error:
```bash
Argument of type '{ strokeWidth: string; size: number; color: string; }' is not assignable to parameter of type 'SVGProps'.
  Object literal may only specify known properties, but 'strokeWidth' does not exist in type 'SVGProps'. Did you mean to write 'stroke-width'?ts(2345)
(property) strokeWidth: string
```

Adding strokeWidth property as string/number so it can be used both ways, `stroke-width="2"` and `:stroke-width="2"`, without displaying any errors