### PR TITLE
fix: Added non-ascii comment to make sass include css charset

### DIFF
--- a/.build/iconfont.scss
+++ b/.build/iconfont.scss
@@ -50,3 +50,5 @@ $ti-icon-<%= glyph.name %>: unicode('<%= glyph.unicode[0].codePointAt(0).toStrin
 
 <% glyphs.forEach(function(glyph) { %>
 .#{$ti-prefix}-<%= glyph.name %>:before { content: $ti-icon-<%= glyph.name %>; }<% }); %>
+
+/*! Force SASS to include charset:  */

--- a/packages/icons-webfont/.build/iconfont.scss
+++ b/packages/icons-webfont/.build/iconfont.scss
@@ -43,3 +43,5 @@ $ti-icon-<%= glyph.name %>: unicode('<%= glyph.unicode[0].codePointAt(0).toStrin
 
 <% glyphs.forEach(function(glyph) { %>
 .#{$ti-prefix}-<%= glyph.name %>:before { content: $ti-icon-<%= glyph.name %>; }<% }); %>
+
+/*! Force SASS to include charset:  */


### PR DESCRIPTION
Related to #843 - apparently the SASS compiler ignores the `@charset` rule if the output CSS file doesn't include non-ascii characters.

All the unicode characters in the CSS files are escaped, so SASS doesn't see them:
```css
.ti-12-hours:before {
  content: "\fc53";
}
```

Including a comment with a non-ascii character forces sass to include it:
![non-ascii comment](https://github.com/tabler/tabler-icons/assets/28161629/35546a14-bf29-4252-ac43-f12fbe01376d)

![charset the the beginning of the file](https://github.com/tabler/tabler-icons/assets/28161629/d204fa0d-fa4e-4b66-ab74-209a20a84379)

