### PR TITLE
Make web fonts compile again using the compile-options.json

### DIFF
--- a/.build/helpers.mjs
+++ b/.build/helpers.mjs
@@ -281,9 +281,9 @@ export const getCompileOptions = () => {
     fontForge: 'fontforge'
   }
 
-  if (fs.existsSync('../compile-options.json')) {
+  if (fs.existsSync('../../compile-options.json')) {
     try {
-      const tempOptions = JSON.parse(fs.readFileSync('../compile-options.json').toString())
+      const tempOptions = JSON.parse(fs.readFileSync('../../compile-options.json').toString())
 
       if (typeof tempOptions !== 'object') {
         throw 'Compile options file does not contain an json object'

--- a/README.md
+++ b/README.md
@@ -263,23 +263,26 @@ The default settings if you have not defined the file will be:
 ```JSON
 {
   "includeIcons": [],
-  "fontForge": "fontforge",
   "strokeWidth": null
 }
 ```
 
-The fontforge executable needs to be in the path or you can set the path to the downloaded fontforge executable in the configuration file. If you installed in on a mac in your application directory it will be `/Applications/FontForge.app/Contents/MacOS/FontForge`. You can set this value in the `compile-options.json` file.
+The fontforge executable needs to be in the path or you can set the path to the downloaded fontforge executable in the configuration file. If you installed in on a mac in your application directory it will be `/Applications/FontForge.app/Contents/MacOS/FontForge`. You change  this value in the packages/icons-webfont/package.json. For example
 
 ```JSON
 {
-  "fontForge": "/Applications/FontForge.app/Contents/MacOS/FontForge"
+ "build:fix-outline": "/Applications/FontForge.app/Contents/MacOS/FontForge -lang=py -script .build/fix-outline.py",
 }
 ```
 
 To compile the fonts run:
 ```sh
-npm run build-iconfont
+npm run build:webfont
 ```
+
+After compiling the result files will be located in 
+`packages/icons-webfont`
+
 
 By default the stroke width is 2. You can change the stroke width in the `compile-options.json`
 ```JSON

--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
     "svg-outline-stroke": "1.3.1",
     "svgo": "^2.8.0",
     "svgpath": "^2.6.0",
-    "svgson": "^5.2.1"
+    "svgson": "^5.2.1",
+    "webfont": "11.2.26",
+    "sass":"1.69.4"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
Hi,
Thank you for the great icon set.

I have tried to compile the webfonts using compile-options.json (this worked in an earlier edition) But at some point this feature was broken. I have repaired it and updated the documentation because the compilation is a bit different than before. 

There was a compilation problem. the sass and webfont packages where missing from the main package.json. Since these are not in my path I had to fix it by adding the packages.

I hope this commit wil help you and others

Tijmen