### PR TITLE
Fix build script python errors

### DIFF
--- a/packages/icons-webfont/.build/fix-outline.py
+++ b/packages/icons-webfont/.build/fix-outline.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import fontforge
 
 file = sys.argv[1]


### PR DESCRIPTION
All invocations of this script were emitting an error: `NameError: name 'sys' is not defined`.

