### PR TITLE
fix: Preact adapter spreading props as children

### DIFF
--- a/packages/icons-preact/src/createPreactComponent.ts
+++ b/packages/icons-preact/src/createPreactComponent.ts
@@ -33,9 +33,9 @@ const createPreactComponent = (
               stroke: color,
             }),
         style,
+        ...rest,
       },
       [...iconNode.map(([tag, attrs]) => h(tag, attrs)), ...toChildArray(children)],
-      ...[rest],
     );
 
   Component.displayName = `${iconNamePascal}`;


### PR DESCRIPTION
The Preact adapter has a bug where it spreads the remaining `props` as if they were children. But because random objects are not allowed to be rendered to prevent security vulnerabilities, Preact will throw an error. This works the same way in React.

![Screenshot 2024-04-09 at 12 05 22](https://github.com/tabler/tabler-icons/assets/1062408/65a27bb1-8096-481f-8dec-758668a8067a)

This issue can be fixed by spreading the remaining `rest` props into `props` where they belong. Basically, the same way as it's done in the React adapter.

Fixes https://github.com/denoland/fresh/issues/2400