### PR TITLE
@tabler/icons-vue: Fall back to default if stroke is undefined

### DIFF
--- a/packages/icons-vue/src/createVueComponent.ts
+++ b/packages/icons-vue/src/createVueComponent.ts
@@ -23,7 +23,7 @@ const createVueComponent =
               fill: color,
             }
           : {
-              'stroke-width': stroke,
+              'stroke-width': stroke ?? defaultAttributes[type]['stroke-width'],
               stroke: color,
             }),
         ...rest,


### PR DESCRIPTION
Fixes #1067