### PR TITLE
Add icon `circle-plus` (filled)

### DIFF
--- a/icons/filled/circle-plus.svg
+++ b/icons/filled/circle-plus.svg
@@ -1,0 +1,9 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+>
+  <path fill-rule="evenodd" d="M4.929 4.929A10 10 0 1 1 19.07 19.07 10 10 0 0 1 4.93 4.93ZM13 9a1 1 0 1 0-2 0v2H9a1 1 0 1 0 0 2h2v2a1 1 0 1 0 2 0v-2h2a1 1 0 1 0 0-2h-2V9Z" clip-rule="evenodd"/>
+</svg>


### PR DESCRIPTION
Noticed `circle-plus` (filled) was missing.

![image](https://github.com/tabler/tabler-icons/assets/15910702/e3f87add-1bc4-487e-8390-c0a0ca8d3cb4)

_square-rounded-plus-filled for reference_
