### PR TITLE
Add `buildings` icon

### DIFF
--- a/icons/outline/buildings.svg
+++ b/icons/outline/buildings.svg
@@ -1,0 +1,18 @@
+<!--
+tags: [flat, office, city, urban, scyscraper, architecture, construction]
+category: Buildings
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+  stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 4,21 V 6 C 4,5 5,4 6,4 h 5 c 1,0 2,1 2,2 v 15" />
+  <path d="m 16,8 h 2 c 1,0 2,1 2,2 v 11" />
+  <path d="M3 21H21" />
+  <path d="M10 12V12.01" />
+  <path d="M10 16V16.01" />
+  <path d="M10 8V8.01" />
+  <path d="M7 12V12.01" />
+  <path d="M7 16V16.01" />
+  <path d="M7 8V8.01" />
+  <path d="M17 12V12.01" />
+  <path d="M17 16V16.01" />
+</svg>

--- a/icons/outline/buildings.svg
+++ b/icons/outline/buildings.svg
@@ -2,8 +2,17 @@
 tags: [flat, office, city, urban, scyscraper, architecture, construction]
 category: Buildings
 -->
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-  stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
   <path d="M 4,21 V 6 C 4,5 5,4 6,4 h 5 c 1,0 2,1 2,2 v 15" />
   <path d="m 16,8 h 2 c 1,0 2,1 2,2 v 11" />
   <path d="M3 21H21" />

--- a/icons/outline/buildings.svg
+++ b/icons/outline/buildings.svg
@@ -16,12 +16,12 @@ category: Buildings
   <path d="M 4,21 V 6 C 4,5 5,4 6,4 h 5 c 1,0 2,1 2,2 v 15" />
   <path d="m 16,8 h 2 c 1,0 2,1 2,2 v 11" />
   <path d="M3 21H21" />
-  <path d="M10 12V12.01" />
-  <path d="M10 16V16.01" />
-  <path d="M10 8V8.01" />
-  <path d="M7 12V12.01" />
-  <path d="M7 16V16.01" />
-  <path d="M7 8V8.01" />
-  <path d="M17 12V12.01" />
-  <path d="M17 16V16.01" />
+  <path d="M10 12V12" />
+  <path d="M10 16V16" />
+  <path d="M10 8V8" />
+  <path d="M7 12V12" />
+  <path d="M7 16V16" />
+  <path d="M7 8V8" />
+  <path d="M17 12V12" />
+  <path d="M17 16V16" />
 </svg>


### PR DESCRIPTION
## Preview
![Screenshot 2024-05-27 at 1 29 51 PM](https://github.com/tabler/tabler-icons/assets/12821361/f6db44f7-5601-4ced-8caf-781e63edcbdb)

## Reasoning

I based it on the `user` and `users` icons:

![Screenshot 2024-05-27 at 1 32 55 PM](https://github.com/tabler/tabler-icons/assets/12821361/a47b554d-aee8-463f-a195-935d3eb10d1d)
![Screenshot 2024-05-27 at 1 33 13 PM](https://github.com/tabler/tabler-icons/assets/12821361/2784448c-ac71-4e26-b0f9-b08d16d0f413)
