### PR TITLE
Add icon `building-off`

### DIFF
--- a/icons/outline/building-off.svg
+++ b/icons/outline/building-off.svg
@@ -1,0 +1,25 @@
+<!--
+tags: [flat, office, city, urban, scyscraper, architecture, construction]
+category: Buildings
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 21l18 0" />
+  <path d="M9 8l1 0" />
+  <path d="M9 12l1 0" />
+  <path d="M9 16l1 0" />
+  <path d="M14 8l1 0" />
+  <path d="M14 12l1 0" />
+  <path d="M14 16l1 0" />
+  <path d="M 5,21 V 5 M 7,3 h 10 c 1,0 2,1 2,2 v 10 m 0,4 v 2" />
+  <path d="M 3,3 21,21" />
+</svg>


### PR DESCRIPTION
![Screenshot 2024-05-28 at 4 26 52 PM](https://github.com/tabler/tabler-icons/assets/12821361/98796812-3f29-498c-b53d-d1789bba1e09)

## Alternative versions
I kept the dots (representing windows) because otherwise it looked very different from the regular icon. This would be the alternative:
![Screenshot 2024-05-28 at 4 29 16 PM](https://github.com/tabler/tabler-icons/assets/12821361/08eb6703-056d-492a-abb0-34d4504bdbad)

![Screenshot 2024-05-28 at 4 29 47 PM](https://github.com/tabler/tabler-icons/assets/12821361/d258eb17-0dd7-4e50-a1ab-e31ed29c46ed)
