### PR TITLE
Fix: Correct category in metadata of cash-register.svg

### DIFF
--- a/icons/outline/cash-register.svg
+++ b/icons/outline/cash-register.svg
@@ -1,6 +1,6 @@
 <!--
 tags: [payment, money, pay, cashier, register, purchase, checkout, transaction]
-category: E-commerse
+category: E-commerce
 unicode: "fee6"
 version: "3.4"
 -->


### PR DESCRIPTION
Category: Changed from `E-commerse` to `E-commerce`