### PR TITLE
Add icon `ruler-measure-2`

### DIFF
--- a/icons/outline/ruler-measure-2.svg
+++ b/icons/outline/ruler-measure-2.svg
@@ -1,0 +1,25 @@
+<!--
+tags: [maths, dimensions, size, width, length, geometry, measure, technical, distance]
+category: Design
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+ <path d="M12 19.875c0 .621-.512 1.125-1.143 1.125H5.143A1.134 1.134 0 0 1 4 19.875V4a1 1 0 0 1 1-1h5.857C11.488 3 12 3.504 12 4.125Z" />
+ <path d="M12 9h-2" />
+ <path d="M12 6H9" />
+ <path d="M12 12H9" />
+ <path d="M12 18H9" />
+ <path d="M12 15h-2" />
+ <path d="M21 3h-4" />
+ <path d="M19 3v18" />
+ <path d="M21 21h-4" />
+</svg>

--- a/icons/outline/ruler-measure.svg
+++ b/icons/outline/ruler-measure.svg
@@ -1,5 +1,5 @@
 <!--
-tags: [maths, dimensions, size, width, length, geometry, measure, technical]
+tags: [maths, dimensions, size, width, length, geometry, measure, technical, distance]
 version: "1.78"
 unicode: "f291"
 category: Design


### PR DESCRIPTION
Solves https://github.com/tabler/tabler-icons/issues/1023

 <img width="100" alt="efrds" src="https://github.com/tabler/tabler-icons/assets/12821361/49095153-dc07-480e-9e62-2d61f193e188">

I don't know how to rename `ruler-measure` to `ruler-measure-hotizontal`, so I leave it as si.

