### PR TITLE
Add icon `rosette-discount-check-off`

### DIFF
--- a/icons/outline/rosette-discount-check-off.svg
+++ b/icons/outline/rosette-discount-check-off.svg
@@ -1,0 +1,19 @@
+<!--
+tags: [reduction, price, cost, money, shopping, bargain, tick, done, verified, certificate, valid, official, success, invalid]
+category: E-commerce
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m9 12 2 2 1.5-1.5m2-2 .5-.5" />
+  <path d="M8.887 4.89a2.2 2.2 0 0 0 .863 -.53l.7 -.7a2.2 2.2 0 0 1 3.12 0l.7 .7c.412 .41 .97 .64 1.55 .64h1a2.2 2.2 0 0 1 2.2 2.2v1c0 .58 .23 1.138 .64 1.55l.7 .7a2.2 2.2 0 0 1 0 3.12l-.7 .7a2.2 2.2 0 0 0 -.528 .858m-.757 3.248a2.193 2.193 0 0 1 -1.555 .644h-1a2.2 2.2 0 0 0 -1.55 .64l-.7 .7a2.2 2.2 0 0 1 -3.12 0l-.7 -.7a2.2 2.2 0 0 0 -1.55 -.64h-1a2.2 2.2 0 0 1 -2.2 -2.2v-1a2.2 2.2 0 0 0 -.64 -1.55l-.7 -.7a2.2 2.2 0 0 1 0 -3.12l.7 -.7a2.2 2.2 0 0 0 .64 -1.55v-1c0 -.604 .244 -1.152 .638 -1.55" />
+  <path d="M3 3l18 18" />
+</svg>

--- a/icons/outline/rosette-discount-check.svg
+++ b/icons/outline/rosette-discount-check.svg
@@ -1,6 +1,6 @@
 <!--
+tags: [reduction, price, cost, money, shopping, bargain, tick, done, verified, certificate, valid, official, success]
 category: E-commerce
-tags: [reduction, price, cost, money, shopping, bargain, tick, done]
 version: "1.70"
 unicode: "f1f8"
 -->


### PR DESCRIPTION
From this suggestion: https://github.com/tabler/tabler-icons/issues/902

<img width="24" alt="Screenshot 2024-06-09 at 5 45 55 PM" src="https://github.com/tabler/tabler-icons/assets/12821361/ab2cc261-daa3-4276-ba8c-a53a573aac96">
