### PR TITLE
Add <title> to <svg> in SolidJS

### DIFF
--- a/packages/icons-solidjs/src/createSolidComponent.ts
+++ b/packages/icons-solidjs/src/createSolidComponent.ts
@@ -10,13 +10,14 @@ const createSolidComponent = (
   iconNode: IconNode,
 ) => {
   const Component = (props: IconProps) => {
-    const [localProps, rest] = splitProps(props, ['color', 'size', 'stroke', 'children', 'class']),
+    const [localProps, rest] = splitProps(props, ['color', 'size', 'stroke', 'title', 'children', 'class']),
       attributes = defaultAttributes[type];
 
     const svgProps = {
       ...attributes,
       width: () => (localProps.size != null ? localProps.size : attributes.width),
       height: () => (localProps.size != null ? localProps.size : attributes.height),
+      title: () => localProps.title != null ? localProps.title : undefined,
       ...(type === 'filled'
         ? {
             fill: () => (localProps.color != null ? localProps.color : 'currentColor'),
@@ -33,7 +34,11 @@ const createSolidComponent = (
     return h(
       'svg',
       [svgProps, rest],
-      [...iconNode.map(([tag, attrs]) => h(tag, attrs)), localProps.children],
+      [
+        localProps.title && h('title', {}, localProps.title),
+        ...iconNode.map(([tag, attrs]) => h(tag, attrs)),
+        localProps.children
+      ],
     );
   };
 

--- a/packages/icons-solidjs/src/types.ts
+++ b/packages/icons-solidjs/src/types.ts
@@ -8,5 +8,6 @@ export interface IconProps extends SVGAttributes {
   color?: string;
   size?: string | number;
   strokeWidth?: string | number;
+  title?: string;
   class?: string;
 }


### PR DESCRIPTION
Adds <title> child tag & title property in built package, but still doesn't show it on hover (more tests required)