### PR TITLE
Fix `battery-automotive` icon

### DIFF
--- a/icons/outline/battery-automotive.svg
+++ b/icons/outline/battery-automotive.svg
@@ -15,9 +15,9 @@ unicode: "ee07"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z" />
-  <path d="M6 5v-2" />
-  <path d="M19 3v2" />
+  <path d="M3 7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  <path d="M6 5V3" />
+  <path d="M18 3v2" />
   <path d="M6.5 12h3" />
   <path d="M14.5 12h3" />
   <path d="M16 10.5v3" />


### PR DESCRIPTION
Follow-up of #1126