### PR TITLE
Remove invalid DOM properties from circle-plus.svg

### DIFF
--- a/icons/filled/circle-plus.svg
+++ b/icons/filled/circle-plus.svg
@@ -9,5 +9,5 @@ version: "3.5"
   viewBox="0 0 24 24"
   fill="currentColor"
 >
-  <path fill-rule="evenodd" d="M4.929 4.929A10 10 0 1 1 19.07 19.07 10 10 0 0 1 4.93 4.93ZM13 9a1 1 0 1 0 -2 0v2H9a1 1 0 1 0 0 2h2v2a1 1 0 1 0 2 0v-2h2a1 1 0 1 0 0 -2h-2V9Z" clip-rule="evenodd" />
+  <path d="M4.929 4.929A10 10 0 1 1 19.07 19.07 10 10 0 0 1 4.93 4.93ZM13 9a1 1 0 1 0 -2 0v2H9a1 1 0 1 0 0 2h2v2a1 1 0 1 0 2 0v-2h2a1 1 0 1 0 0 -2h-2V9Z" />
 </svg>


### PR DESCRIPTION
Removed `fill-rule` and `clip-rule` properties in `<path>` element