### PR TITLE
Add icon `brand-metabrainz`

### DIFF
--- a/icons/outline/brand-metabrainz.svg
+++ b/icons/outline/brand-metabrainz.svg
@@ -1,0 +1,18 @@
+<!--
+tags: [website, database, open-source, musicbrainz, listenbrainz, bookbrainz, critiquebrainz]
+category: Brand
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.5 6.5v11l8 4.6V1.9z" />
+  <path d="M21.5 6.5v11l-8 4.6V1.9z" />
+</svg>


### PR DESCRIPTION
I originally wanted to have an icon for [MusicBrainz] in #760, but the small icon without details which worked best as a Tabler icon is also used for [other projects] by the [MetaBrainz Foundation].
The small icon variants are only distinguished by their colors, which are not applicable here for a monochrome icon.

While MusicBrainz is the oldest and most widely known of these projects, it makes more sense to name this brand icon after the foundation. In order to make the icon discoverable by a search for the names of the other projects, I have added tags for the main projects.

Closes #760.

Also see the official MetaBrainz brand logos and their variants [on GitHub](https://github.com/metabrainz/design-system/tree/master/brand/logos).

[MetaBrainz Foundation]: https://metabrainz.org/
[MusicBrainz]: https://musicbrainz.org/
[other projects]: https://metabrainz.org/projects