### PR TITLE
Adds icon `stopwatch`

### DIFF
--- a/icons/outline/stopwatch.svg
+++ b/icons/outline/stopwatch.svg
@@ -1,0 +1,20 @@
+<!--
+tags: [timer, time, watch, clock, run, race]
+version: "1.0"
+category: System
+-->
+<svg 
+	xmlns="http://www.w3.org/2000/svg"
+	width="24"
+	height="24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+>
+	<path d="M5 13a7 7 0 1 0 14 0 7 7 0 0 0-14 0Z"/>
+    <path d="M14.5 10.5 12 13"/>
+    <path d="M17 8 18 7"/>
+    <path d="M14 3h-4"/>
+</svg>


### PR DESCRIPTION
Hello! Noticed a fair amount of clock/alarm icons, but not a specific stopwatch icon. So I whipped one up using the base `alarm` icon as a starting point. Hope this is useful (and that I didn't do anything incorrectly)!

![image](https://github.com/tabler/tabler-icons/assets/695568/8dcda2fb-c16d-40c7-9cef-a486654038a1)
