### PR TITLE
Allow treeshaking with `@tabler/icons-solidjs`

### DIFF
--- a/packages/icons-solidjs/package.json
+++ b/packages/icons-solidjs/package.json
@@ -20,6 +20,7 @@
   "main": "./dist/cjs/tabler-icons-solidjs.cjs",
   "module": "./dist/esm/tabler-icons-solidjs.mjs",
   "types": "./dist/cjs/tabler-icons-solidjs.d.cts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
In my case, I have not seen any issues setting the sideEffects flag globally. This *should* fix all bundling size issues

Closes #1215
Closes #1203