### PR TITLE
Fix preact icon attribute spreading

### DIFF
--- a/packages/icons-preact/src/createPreactComponent.ts
+++ b/packages/icons-preact/src/createPreactComponent.ts
@@ -34,7 +34,7 @@ const createPreactComponent = (
               stroke: color,
             }),
         style,
-        ...[rest],
+        ...rest,
       },
       [
         title && h('title', {}, title),


### PR DESCRIPTION
Currently when passing in html props, e.g. `id="hello"`, to a react icon component would cause the render to show `0="[object Object]"`. This is due to the fact that we are wrapping `rest` in `[rest]`. 

This PR fixes that.