### PR TITLE
Fix ESM resolution in `@tabler/icons-react`

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -17,9 +17,21 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-react"
   },
-  "main": "./dist/cjs/tabler-icons-react.cjs",
-  "types": "./dist/esm/tabler-icons-react.d.ts",
-  "module": "./dist/esm/tabler-icons-react.mjs",
+  "main": "./dist/cjs/tabler-icons-react.js",
+  "types": "./dist/cjs/tabler-icons-react.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/esm/tabler-icons-react.d.mts",
+        "default": "./dist/esm/tabler-icons-react.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/tabler-icons-react.d.ts",
+        "default": "./dist/cjs/tabler-icons-react.js"
+      }
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist"

--- a/packages/icons-react/rollup.config.mjs
+++ b/packages/icons-react/rollup.config.mjs
@@ -9,7 +9,7 @@ const inputs = ['./src/tabler-icons-react.ts'];
 const bundles = [
   {
     format: 'cjs',
-    extension: 'cjs',
+    extension: 'js',
     inputs,
   },
   {
@@ -24,9 +24,9 @@ export default [
   {
     input: inputs[0],
     output: [{
-      file: `dist/esm/${outputFileName}.d.ts`, format: 'esm'
+      file: `dist/esm/${outputFileName}.d.mts`, format: 'esm'
     }, {
-      file: `dist/cjs/${outputFileName}.d.cts`, format: 'cjs'
+      file: `dist/cjs/${outputFileName}.d.ts`, format: 'cjs'
     }],
     plugins: [dts()],
   },


### PR DESCRIPTION
## Issue

Currently the ESM environment still resolves to CJS exports, according to [AreTheTypesWrong](https://arethetypeswrong.github.io/?p=@tabler/icons-react@3.18.0):
![CleanShot 2024-09-27 at 22 04 21@2x](https://github.com/user-attachments/assets/213520fc-982b-4664-baf8-e660bd5265d2)

## Changes made

I've fixed the file extensions settings in `rollup.config`: `.js`/`.ts`for CJS and `.mjs`/`.mts` for ESM (since there's no `type: module` in `package.json`).

I've also included `exports` in the `package.json` to explicitly specify files to resolve to.

Now all the environments resolve correctly:
![CleanShot 2024-09-27 at 22 02 32@2x](https://github.com/user-attachments/assets/71918903-010b-410c-9297-2e4d63729345)

