### PR TITLE
x power y icon added [Fixes #1241]

### DIFF
--- a/icons/outline/x-power-y.svg
+++ b/icons/outline/x-power-y.svg
@@ -1,8 +1,6 @@
 <!--
 tags: [math, expression, equation, power, raised]
 category: Math
-unicode: "eb81"
-version: "3.19.1"
 -->
 <svg
  xmlns="http://www.w3.org/2000/svg" 

--- a/icons/outline/x-power-y.svg
+++ b/icons/outline/x-power-y.svg
@@ -5,6 +5,7 @@ unicode: "eb81"
 version: "3.19.1"
 -->
 <svg
+ xmlns="http://www.w3.org/2000/svg" 
  width="24"
  height="24"
  viewBox="0 0 24 24"

--- a/icons/outline/x-power-y.svg
+++ b/icons/outline/x-power-y.svg
@@ -1,0 +1,22 @@
+<!--
+tags: [math, expression, equation, power, raised]
+category: Math
+unicode: "eb81"
+version: "3.19.1"
+-->
+<svg
+ width="24"
+ height="24"
+ viewBox="0 0 24 24"
+ fill="none"
+ stroke="currentColor"
+ stroke-width="2"
+ stroke-linecap="round"
+ stroke-linejoin="round"
+>
+  <path d="M15 3l3 5.063" />
+  <path d="M5 12l6 6" />
+  <path d="M5 18l6 -6" />
+  <path d="M21 3l-4.8 9" />
+</svg>
+ 


### PR DESCRIPTION
Icon name
x raised to the power y [Fixes #1241]

Use cases
Right now we only have superscript to symbolise x raised to the power 2

(https://github.com/tabler/tabler-icons/blob/8d4f23166d708b42bacc5ce4bc73d72ba296057b/icons/outline/superscript.svg?plain=1#L1)
To have the option to raise it to the power y, I have added this icon.

Design ideas

<img width="35" alt="Screenshot 2024-10-09 at 10 32 23 PM" src="https://github.com/user-attachments/assets/b318bb66-75a0-424c-9b38-9cdf5bee2582">
