### PR TITLE
Tag plus & Tag minus

### DIFF
--- a/icons/outline/tag-minus.svg
+++ b/icons/outline/tag-minus.svg
@@ -1,56 +1,21 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 category: E-commerce
 tags: [label, price]
 version: "1.0"
 unicode: "eb34"
 -->
-
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
-   fill="none"
-   stroke="currentColor"
-   stroke-width="2"
-   stroke-linecap="round"
-   stroke-linejoin="round"
-   version="1.1"
-   id="svg2"
-   sodipodi:docname="tag-minus.svg"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="namedview2"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="18.649941"
-     inkscape:cx="16.595226"
-     inkscape:cy="13.967872"
-     inkscape:window-width="1440"
-     inkscape:window-height="891"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <path
-     d="M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"
-     id="path1" />
-  <path
-     d="m 18.898,16.102 0.699,-0.699 0.699,-0.699 c 0.940994,-0.941134 0.940994,-2.466866 0,-3.408 l -7.71,-7.71 C 12.211015,3.2109013 11.70239,3.0001133 11.172,3 H 6 C 4.3431458,3 3,4.3431458 3,6 v 5.172 c 1.133e-4,0.53039 0.2109013,1.039015 0.586,1.414 l 7.71,7.71 c 0.470567,0.470497 1.087284,0.705745 1.704,0.705745"
-     id="path2"
-     sodipodi:nodetypes="ccccccsscccc" />
-  <path
-     d="m 16,19 h 6"
-     id="path5" />
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+  <path d="m 18.898,16.102 0.699,-0.699 0.699,-0.699 c 0.940994,-0.941134 0.940994,-2.466866 0,-3.408 l -7.71,-7.71 C 12.211015,3.2109013 11.70239,3.0001133 11.172,3 H 6 C 4.3431458,3 3,4.3431458 3,6 v 5.172 c 1.133e-4,0.53039 0.2109013,1.039015 0.586,1.414 l 7.71,7.71 c 0.470567,0.470497 1.087284,0.705745 1.704,0.705745" />
+  <path d="m 16,19 h 6" />
 </svg>

--- a/icons/outline/tag-minus.svg
+++ b/icons/outline/tag-minus.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+category: E-commerce
+tags: [label, price]
+version: "1.0"
+unicode: "eb34"
+-->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   stroke="currentColor"
+   stroke-width="2"
+   stroke-linecap="round"
+   stroke-linejoin="round"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="tag-minus.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="18.649941"
+     inkscape:cx="16.595226"
+     inkscape:cy="13.967872"
+     inkscape:window-width="1440"
+     inkscape:window-height="891"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"
+     id="path1" />
+  <path
+     d="m 18.898,16.102 0.699,-0.699 0.699,-0.699 c 0.940994,-0.941134 0.940994,-2.466866 0,-3.408 l -7.71,-7.71 C 12.211015,3.2109013 11.70239,3.0001133 11.172,3 H 6 C 4.3431458,3 3,4.3431458 3,6 v 5.172 c 1.133e-4,0.53039 0.2109013,1.039015 0.586,1.414 l 7.71,7.71 c 0.470567,0.470497 1.087284,0.705745 1.704,0.705745"
+     id="path2"
+     sodipodi:nodetypes="ccccccsscccc" />
+  <path
+     d="m 16,19 h 6"
+     id="path5" />
+</svg>

--- a/icons/outline/tag-plus.svg
+++ b/icons/outline/tag-plus.svg
@@ -1,59 +1,22 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 category: E-commerce
 tags: [label, price]
 version: "1.0"
 unicode: "eb34"
 -->
-
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
-   fill="none"
-   stroke="currentColor"
-   stroke-width="2"
-   stroke-linecap="round"
-   stroke-linejoin="round"
-   version="1.1"
-   id="svg2"
-   sodipodi:docname="tag-plus.svg"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="namedview2"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="18.649941"
-     inkscape:cx="16.595226"
-     inkscape:cy="13.967872"
-     inkscape:window-width="1440"
-     inkscape:window-height="891"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <path
-     d="M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"
-     id="path1" />
-  <path
-     d="m 21.001745,13 c 0,-0.616716 -0.235248,-1.233433 -0.705745,-1.704 l -7.71,-7.71 C 12.211015,3.2109013 11.70239,3.0001133 11.172,3 H 6 C 4.3431458,3 3,4.3431458 3,6 v 5.172 c 1.133e-4,0.53039 0.2109013,1.039015 0.586,1.414 l 7.71,7.71 c 0.470567,0.470497 1.087283,0.705745 1.704,0.705745"
-     id="path2"
-     sodipodi:nodetypes="ccccsscccc" />
-  <path
-     d="m 16,19 h 6"
-     id="path5" />
-  <path
-     d="m 19,16 v 6"
-     id="path6" />
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"/>
+  <path d="m 21.001745,13 c 0,-0.616716 -0.235248,-1.233433 -0.705745,-1.704 l -7.71,-7.71 C 12.211015,3.2109013 11.70239,3.0001133 11.172,3 H 6 C 4.3431458,3 3,4.3431458 3,6 v 5.172 c 1.133e-4,0.53039 0.2109013,1.039015 0.586,1.414 l 7.71,7.71 c 0.470567,0.470497 1.087283,0.705745 1.704,0.705745" />
+  <path d="m 16,19 h 6" />
+  <path d="m 19,16 v 6" />
 </svg>

--- a/icons/outline/tag-plus.svg
+++ b/icons/outline/tag-plus.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+category: E-commerce
+tags: [label, price]
+version: "1.0"
+unicode: "eb34"
+-->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   stroke="currentColor"
+   stroke-width="2"
+   stroke-linecap="round"
+   stroke-linejoin="round"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="tag-plus.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="18.649941"
+     inkscape:cx="16.595226"
+     inkscape:cy="13.967872"
+     inkscape:window-width="1440"
+     inkscape:window-height="891"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="M7.5 7.5m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0"
+     id="path1" />
+  <path
+     d="m 21.001745,13 c 0,-0.616716 -0.235248,-1.233433 -0.705745,-1.704 l -7.71,-7.71 C 12.211015,3.2109013 11.70239,3.0001133 11.172,3 H 6 C 4.3431458,3 3,4.3431458 3,6 v 5.172 c 1.133e-4,0.53039 0.2109013,1.039015 0.586,1.414 l 7.71,7.71 c 0.470567,0.470497 1.087283,0.705745 1.704,0.705745"
+     id="path2"
+     sodipodi:nodetypes="ccccsscccc" />
+  <path
+     d="m 16,19 h 6"
+     id="path5" />
+  <path
+     d="m 19,16 v 6"
+     id="path6" />
+</svg>


### PR DESCRIPTION
Add tag-plus and tag-minus

Fixes #1240 

> ### Icon name
> tag-plus, tag-minus
> 
> ### Use cases
> Tags are used in variety of products to classify stuffs, adding and removing tags is quite a common operation, thus might be interesting
> 
> ### Design ideas
> just like other IconCubePlus, or IconFlagMinus
> 
> ### Checklist
> * [x]  I have searched if someone has submitted a similar issue before and there weren't any. (Please make sure to also search closed issues, as this issue might already have been resolved.)
> * [x]  I have searched existing icons to make sure it does not already exist and I didn't find any.
> * [x]  I am not requesting a brand logo and the art is not protected by copyright.
> * [x]  I have provided appropriate use cases for the icon(s) requested.