### PR TITLE
Video Filled

### DIFF
--- a/icons/filled/video.svg
+++ b/icons/filled/video.svg
@@ -1,0 +1,15 @@
+<!--
+category: Media
+tags: [film, shoot, recording, taping, camera]
+version: "1.25"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+>
+  <path d="M 20.117188,7.625 A 1,1 0 0 0 19.552734,7.724609 L 15,10 v 4 l 4.552734,2.275391 A 1,1 0 0 0 21,15.382812 V 8.6171875 A 1,1 0 0 0 20.117188,7.625 Z" />
+  <path d="M 5,5 C 3.3549936,5 2,6.3549936 2,8 v 8 c 0,1.645006 1.3549936,3 3,3 h 8 c 1.645006,0 3,-1.354994 3,-3 V 8 C 16,6.3549936 14.645006,5 13,5 Z" />
+</svg>


### PR DESCRIPTION
Add filled video icon

Fixes #1242 

> ### Icon name
> IconVideoFilled
> 
> ### Use cases
> I need to display a filled variant of the video icon when a user selects a sidebar item with the outline version. I need to display a filled variant of the video icon in some design scenarios where the icon is on a solid background. Similar to the image below.
> 
> ### Design ideas
> ![image](https://private-user-images.githubusercontent.com/44934037/375053137-fb5ca1ed-db52-4b22-ae3d-f712d8130444.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjg2NzE1MjcsIm5iZiI6MTcyODY3MTIyNywicGF0aCI6Ii80NDkzNDAzNy8zNzUwNTMxMzctZmI1Y2ExZWQtZGI1Mi00YjIyLWFlM2QtZjcxMmQ4MTMwNDQ0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDExVDE4MjcwN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWI3NzU2YWMyNWM1ZTU3NmY5M2I3ZTdjZmY3ZjE2NjE1ZDA1ODBjNzE4NTMwMWYzODViYzQ4ZWJlMmI0YmJhM2UmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Y0QWy5p2zER9z03p3DH1KbFCnVc5Ztb2rjbW4FPs058)
> 
> ### Checklist
> * [x]  I have searched if someone has submitted a similar issue before and there weren't any. (Please make sure to also search closed issues, as this issue might already have been resolved.)
> * [x]  I have searched existing icons to make sure it does not already exist and I didn't find any.
> * [x]  I am not requesting a brand logo and the art is not protected by copyright.
> * [x]  I have provided appropriate use cases for the icon(s) requested.

