### PR TITLE
1 new icon: `outline/ferry`

### DIFF
--- a/icons/outline/ferry.svg
+++ b/icons/outline/ferry.svg
@@ -1,7 +1,6 @@
 <!--
 tags: [ferry, sea, ocean, engine, travel, lake]
 category: Vehicles
-version: "3.19"
 -->
 <svg
   xmlns="http://www.w3.org/2000/svg"

--- a/icons/outline/ferry.svg
+++ b/icons/outline/ferry.svg
@@ -1,0 +1,20 @@
+<!--
+tags: [ferry, sea, ocean, engine, travel, lake]
+category: Vehicles
+version: "3.19"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 17h14.08a3 3 0 0 0 2.5-1.34L21.721 13H4.5z"/>
+  <path d="m14.556 7.959-.382-1.415"/>
+  <path d="M6.107 12.675 7.491 8h8l2.675 4.598"/>
+</svg>


### PR DESCRIPTION
Add ferry icon

Submitting this because I need it.
> 
> ### Icon name
> ferry
> 
> ## Use cases
> Ferries are a popular mode of transportation in coastal cities and islands. A ferry icon would be useful in navigation apps, travel platforms, or public transport schedules to represent ferry routes or terminals.
> 
> ## Design ideas
> The ferry icon could resembles a simple side view of a ferry boat, with basic elements like a smokestack and a deck. It is modeled after other transportation icons, such as the bus, train icons and speedboat, to ensure stylistic consistency.
> 
> Checklist
> - [x] I have searched if someone has submitted a similar issue before and there weren't any. (Please make sure to also search closed issues, as this issue might already have been resolved.)
> - [x] I have searched existing icons to make sure it does not already exist and I didn't find any.
> - [x] I am not requesting a brand logo and the art is not protected by copyright.
> - [x] I have provided appropriate use cases for the icon(s) requested.