### PR TITLE
Added floor division icon [Fixes #1252]

### DIFF
--- a/icons/outline/math-x-floor-divide-y.svg
+++ b/icons/outline/math-x-floor-divide-y.svg
@@ -1,0 +1,27 @@
+<!--
+tags: [math, expression, equation, floor, division]
+category: Math
+unicode: "244a"
+version: "3.19.1"
+-->
+<svg
+ xmlns="http://www.w3.org/2000/svg" 
+ width="24" 
+ height="24" 
+ viewBox="0 0 24 24" 
+ fill="none" 
+ stroke="currentColor" 
+ stroke-width="2" 
+ stroke-linecap="round" 
+ stroke-linejoin="round"
+>
+  <path d="M1 19l18 -18"></path>
+  <path d="M5 22l18 -18"></path>
+  <path d="M18 15l3 4.5"></path>
+  <path d="M23 15l-4.5 9"></path>
+  <path d="M1 1l6 6"></path>
+  <path d="M1 7l6 -6"></path>
+</svg>
+
+ 
+ 

--- a/icons/outline/math-x-floor-divide-y.svg
+++ b/icons/outline/math-x-floor-divide-y.svg
@@ -15,10 +15,10 @@ version: "3.19.1"
  stroke-linecap="round" 
  stroke-linejoin="round"
 >
-  <path d="M1 19l18 -18"></path>
-  <path d="M5 22l18 -18"></path>
-  <path d="M18 15l3 4.5"></path>
-  <path d="M23 15l-4.5 9"></path>
+  <path d="M1.5 19l18 -18"></path>
+  <path d="M4.5 22l18 -18"></path>
+  <path d="M18 15l3 4"></path>
+  <path d="M23 15l-4.5 8"></path>
   <path d="M1 1l6 6"></path>
   <path d="M1 7l6 -6"></path>
 </svg>

--- a/icons/outline/math-x-floor-divide-y.svg
+++ b/icons/outline/math-x-floor-divide-y.svg
@@ -1,8 +1,6 @@
 <!--
 tags: [math, expression, equation, floor, division]
 category: Math
-unicode: "244a"
-version: "3.19.1"
 -->
 <svg
  xmlns="http://www.w3.org/2000/svg" 
@@ -22,6 +20,3 @@ version: "3.19.1"
   <path d="M1 1l6 6"></path>
   <path d="M1 7l6 -6"></path>
 </svg>
-
- 
- 


### PR DESCRIPTION
Fixes #1252
Icon name
Floor Division

Use cases
used to calculate floor division x//y

Design ideas
<img width="36" alt="Screenshot 2024-10-18 at 1 15 06 PM" src="https://github.com/user-attachments/assets/5cfd25d4-3caf-415e-be61-218cdfe12ff4">
