### PR TITLE
Remove sass deprecation warnings

### DIFF
--- a/.build/iconfont.scss
+++ b/.build/iconfont.scss
@@ -3,6 +3,8 @@
  * Tabler Icons <%= v %> by tabler - https://tabler.io
  * License - https://github.com/tabler/tabler-icons/blob/master/LICENSE
  */
+@use "sass:string";
+
 $ti-font-family: '<%= fileName %>' !default;
 $ti-font-path: 'fonts' !default;
 $ti-font-display: null !default;
@@ -42,7 +44,7 @@ $ti-prefix: 'ti' !default;
   -moz-osx-font-smoothing: grayscale;
 }
 @function unicode($str) {
-  @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\"")
+  @return string.unquote("\"")+string.unquote(string.insert($str, "\\", 1))+string.unquote("\"")
 }
 
 <% glyphs.forEach(function(glyph) { %>

--- a/packages/icons-webfont/.build/iconfont.scss
+++ b/packages/icons-webfont/.build/iconfont.scss
@@ -3,6 +3,8 @@
  * Tabler Icons <%= v %> by tabler - https://tabler.io
  * License - https://github.com/tabler/tabler-icons/blob/master/LICENSE
  */
+@use "sass:string";
+
 $ti-font-family: '<%= fileName %>' !default;
 $ti-font-path: './fonts' !default;
 $ti-font-display: null !default;
@@ -33,7 +35,7 @@ $ti-prefix: 'ti' !default;
 }
 
 @function unicode($str) {
-  @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\"")
+  @return string.unquote("\"")+string.unquote(string.insert($str, "\\", 1))+string.unquote("\"")
 }
 
 <% glyphs.forEach(function(glyph) { %>


### PR DESCRIPTION
Global built-in functions are deprecated and will be removed in dart sass 3.0.0. This commit updates several lines in iconfont files that were causing this deprecation warning.

Fixes #1255 