### PR TITLE
types.ts: Prefix the exported SvelteComponent type with typeof

### DIFF
--- a/packages/icons-svelte/src/types.ts
+++ b/packages/icons-svelte/src/types.ts
@@ -20,4 +20,4 @@ type IconSlots = {
   default: {};
 };
 
-export type Icon = SvelteComponent<IconProps, IconEvents, IconSlots>;
+export type Icon = typeof SvelteComponent<IconProps, IconEvents, IconSlots>;


### PR DESCRIPTION
This fixes the issue:
```
Argument of type 'Icon' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent | Component<any, any, any> | null | undefined'.
  Type 'SvelteComponent<IconProps, IconEvents, IconSlots>' is not assignable to type 'Component<any, any, any>'.
    Type 'SvelteComponent<IconProps, IconEvents, IconSlots>' provides no match for the signature '(this: void, internals: Brand<"ComponentInternals">, props: any): any'.

Possible causes:
- You use the instance type of a component where you should use the constructor type
- Type definitions are missing for this Svelte Component.
```
when doing:
```svelte
<script lang="ts">
    import type { Icon as IconType } from '@tabler/icons-svelte';
    interface Props {
        appendButtons?: {icon: IconType, title: string, disabled?: boolean, onclick: () => void}[];
    };
    let { appendButtons = [] }: Props = $props();
</script>
{#each appendButtons as {icon: Icon, title, disabled, onclick}, index}
	<a href="/" {onclick} class="link-secondary {index !== 0 ? 'ms-2' : ''} {disabled ? 'disabled' : ''}" {title} aria-label={title} data-bs-toggle="tooltip"><Icon/></a>
{/each}
```