### PR TITLE
Upgrade icons-react react version 

### DIFF
--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -38,12 +38,13 @@
     "@tabler/icons": "3.31.0"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.2.1",
-    "@types/react": "18.2.60",
+    "@testing-library/react": "^16.2.0",
+    "@types/react": "19.0.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-test-renderer": "18.2.0"
+    "jsdom": "^26.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-test-renderer": "19.0.0"
   },
   "peerDependencies": {
     "react": ">= 16"

--- a/packages/icons-react/src/types.ts
+++ b/packages/icons-react/src/types.ts
@@ -1,8 +1,8 @@
 
-import { ForwardRefExoticComponent, FunctionComponent, RefAttributes, ReactSVG } from 'react';
+import { ForwardRefExoticComponent, FunctionComponent, RefAttributes } from 'react';
 export type { ReactNode } from 'react';
 
-export type IconNode = [elementName: keyof ReactSVG, attrs: Record<string, string>][];
+export type IconNode = [elementName: string, attrs: Record<string, string>][];
 
 export interface IconProps extends Partial<Omit<React.ComponentPropsWithoutRef<'svg'>, 'stroke'>> {
   size?: string | number;


### PR DESCRIPTION
Upgraded react and react-dom to latest version 19 and other related dependencies to their latest version.

ReactSVG from react seems to be deprecated and I just replaced it with string type which works fine passing the typechecks.

I am looking forward to any sort of feedback on this