### PR TITLE
fix: Package export file path

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -30,7 +30,7 @@
       },
       "import": {
         "types": "./dist/esm/tabler-icons-react-native.d.ts",
-        "default": "./dist/esm/tabler-icons-react-native.cjs"
+        "default": "./dist/esm/tabler-icons-react-native.mjs"
       }
     }
   },


### PR DESCRIPTION
Fixes the following warning being printed out in new versions of react-native:

```bash
The package /Users/kylebaker/repos/mobile/node_modules/@tabler/icons-react-native contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "/Users/kylebaker/repos/mobile/node_modules/@tabler/icons-react-native" defined in "exports" is /Users/kylebaker/repos/mobile/node_modules/@tabler/icons-react-native/dist/esm/tabler-icons-react-native.cjs, however this file does not exist. Falling back to file-based resolution.
```