### PR TITLE
fix package.json import

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -30,7 +30,7 @@
       },
       "import": {
         "types": "./dist/esm/tabler-icons-react-native.d.ts",
-        "default": "./dist/esm/tabler-icons-react-native.cjs"
+        "default": "./dist/esm/tabler-icons-react-native.mjs"
       }
     }
   },


### PR DESCRIPTION
The import path ./dist/esm/tabler-icons-react-native.cjs doesn't exist

The file is actually named tabler-icons-react-native.mjs (as shown in the "module" field)

"import": {
  "types": "./dist/esm/tabler-icons-react-native.d.ts",
  "default": "./dist/esm/tabler-icons-react-native.mjs"  // Changed from .cjs to .mjs
}