### PR TITLE
Fix filled icons on react native

### DIFF
--- a/packages/icons-react-native/src/createReactNativeComponent.ts
+++ b/packages/icons-react-native/src/createReactNativeComponent.ts
@@ -12,7 +12,8 @@ const createReactNativeComponent = (
   const Component = forwardRef<SVGSVGElement, IconProps>(
     ({ color = 'currentColor', size = 24, strokeWidth = 2, title, children, ...rest }: IconProps, ref) => {
       const customAttrs = {
-        stroke: color,
+        stroke: type === "filled" ? "none" : color,
+        fill: type === "filled" ? color : "none",
         strokeWidth,
         ...rest,
       };


### PR DESCRIPTION
Using the change specified in https://github.com/tabler/tabler-icons/issues/1210