### PR TITLE
Reduce the size of ts bundle

### DIFF
--- a/packages/icons-react-native/rollup.config.mjs
+++ b/packages/icons-react-native/rollup.config.mjs
@@ -1,8 +1,8 @@
-import fs from 'fs'
-import { getRollupConfig } from '../../.build/rollup-plugins.mjs'
-import dts from "rollup-plugin-dts";
+import fs from 'fs';
+import { getRollupConfig } from '../../.build/rollup-plugins.mjs';
+import dts from 'rollup-plugin-dts';
 
-const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'))
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 
 const outputFileName = 'tabler-icons-react-native';
 const inputs = ['./src/tabler-icons-react-native.ts'];
@@ -23,15 +23,20 @@ const bundles = [
 export default [
   {
     input: inputs[0],
-    output: [{
-      file: `dist/esm/${outputFileName}.d.ts`
-    }, {
-      file: `dist/cjs/${outputFileName}.d.cts`
-    }],
+    output: [
+      {
+        dir: `dist/esm`,
+        preserveModules: true,
+      },
+      {
+        dir: `dist/cjs`,
+        preserveModules: true,
+      },
+    ],
     plugins: [dts()],
   },
   ...getRollupConfig(pkg, outputFileName, bundles, {
     react: 'react',
     'react-native-svg': 'react-native-svg',
-  })
+  }),
 ];

--- a/packages/icons-react/rollup.config.mjs
+++ b/packages/icons-react/rollup.config.mjs
@@ -1,8 +1,8 @@
-import fs from 'fs'
-import { getRollupConfig } from '../../.build/rollup-plugins.mjs'
-import dts from "rollup-plugin-dts";
+import fs from 'fs';
+import { getRollupConfig } from '../../.build/rollup-plugins.mjs';
+import dts from 'rollup-plugin-dts';
 
-const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'))
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 
 const outputFileName = 'tabler-icons-react';
 const inputs = ['./src/tabler-icons-react.ts'];
@@ -14,24 +14,29 @@ const bundles = [
   },
   {
     format: 'esm',
-    inputs,
-    preserveModules: true,
     extension: 'mjs',
+    preserveModules: true,
+    inputs,
   },
 ];
 
 export default [
   {
     input: inputs[0],
-    output: [{
-      file: `dist/esm/${outputFileName}.d.ts`, format: 'esm'
-    }, {
-      file: `dist/cjs/${outputFileName}.d.cts`, format: 'cjs'
-    }],
+    output: [
+      {
+        dir: `dist/esm`,
+        preserveModules: true,
+      },
+      {
+        dir: `dist/cjs`,
+        preserveModules: true,
+      },
+    ],
     plugins: [dts()],
   },
 
   ...getRollupConfig(pkg, outputFileName, bundles, {
-    react: 'react'
-  })
+    react: 'react',
+  }),
 ];


### PR DESCRIPTION
Previously, the tabler-icons-react.d.ts file was ~41k lines. This reduces it down to ~5k by importing the relevant types in the main file. 