### PR TITLE
Allow React 19 for react native package by set >16.0 as its already done for react package

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -61,6 +61,6 @@
     "react-test-renderer": "18.2.0"
   },
   "peerDependencies": {
-    "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+    "react": ">= 16.5.1"
   }
 }


### PR DESCRIPTION
See https://github.com/tabler/tabler-icons/blob/v3.34.0/packages/icons-react/package.json#L49

Not sure why this handled differently between react and react native package?