### PR TITLE
Fix: "sytem" category and include tags in these missing icons

### DIFF
--- a/icons/outline/filter-2-bolt.svg
+++ b/icons/outline/filter-2-bolt.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [lightning, fast, quick, speed, energy, electric, zap, power, bolt, electricity]
 unicode: "1015f"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-cancel.svg
+++ b/icons/outline/filter-2-cancel.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [stop, end, terminate, void, abort, cancel, nullify, halt, dismiss, revoke]
 unicode: "1015e"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-check.svg
+++ b/icons/outline/filter-2-check.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [confirm, approve, validate, ok, tick, check, verify, success, complete, yes]
 unicode: "1015d"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-code.svg
+++ b/icons/outline/filter-2-code.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [programming, syntax, script, develop, software, engineer, code, command, logic, algorithm]
 unicode: "1015c"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-cog.svg
+++ b/icons/outline/filter-2-cog.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [gear, settings, mechanism, adjust, configure, cog, engine, tune, optimize, system]
 unicode: "1015b"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-discount.svg
+++ b/icons/outline/filter-2-discount.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [sale, reduction, offer, save, deal, discount, bargain, cheap, cost, cut]
 unicode: "1015a"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-dollar.svg
+++ b/icons/outline/filter-2-dollar.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [currency, money, finance, commerce, cost, dollar, economy, wealth, trade, value]
 unicode: "10159"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-down.svg
+++ b/icons/outline/filter-2-down.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [lower, descend, reduce, decrease, drop, down, minimize, fall, decline, sink]
 unicode: "10158"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-edit.svg
+++ b/icons/outline/filter-2-edit.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [modify, alter, change, revise, update, edit, adjust, correct, amend, rewrite]
 unicode: "10157"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-exclamation.svg
+++ b/icons/outline/filter-2-exclamation.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [alert, warning, important, notice, caution, exclaim, attention, highlight, notify, signal]
 unicode: "10156"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-minus.svg
+++ b/icons/outline/filter-2-minus.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [subtract, reduce, remove, decrease, lessen, deduct, lower, negative, diminish, shrink]
 unicode: "10155"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-pause.svg
+++ b/icons/outline/filter-2-pause.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [stop, halt, break, interrupt, pause, wait, interval, cease, rest, suspend]
 unicode: "10154"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-pin.svg
+++ b/icons/outline/filter-2-pin.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [attach, fix, secure, mark, stick, anchor, place, location, tag, position]
 unicode: "10153"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-plus.svg
+++ b/icons/outline/filter-2-plus.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [add, increase, more, expand, amplify, grow, positive, multiply, enhance]
 unicode: "10152"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-question.svg
+++ b/icons/outline/filter-2-question.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [query, ask, inquire, interrogate, wonder, probe, doubt, curiosity, uncertain, mystery]
 unicode: "10151"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-search.svg
+++ b/icons/outline/filter-2-search.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [find, locate, explore, discover, inspect, seek, detect, look, scan, hunt]
 unicode: "10150"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-share.svg
+++ b/icons/outline/filter-2-share.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [distribute, send, give, show, offer, broadcast, relay, assign, pass, transfer]
 unicode: "1014f"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-spark.svg
+++ b/icons/outline/filter-2-spark.svg
@@ -1,5 +1,5 @@
 <!--
-category: Sytem
+category: System
 unicode: "1014e"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-up.svg
+++ b/icons/outline/filter-2-up.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [increase, raise, ascend, boost, elevate, surge, climb, rise, improve, advance]
 unicode: "1014d"
 version: "3.32"
 -->

--- a/icons/outline/filter-2-x.svg
+++ b/icons/outline/filter-2-x.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [close, exit, remove, delete, cancel, terminate, end, eliminate, stop, cut]
 unicode: "1014c"
 version: "3.32"
 -->

--- a/icons/outline/filter-2.svg
+++ b/icons/outline/filter-2.svg
@@ -1,5 +1,6 @@
 <!--
-category: Sytem
+category: System
+tags: [funnel, hopper, filtration]
 unicode: "1014b"
 version: "3.32"
 -->


### PR DESCRIPTION
I just rename `Sytem` category to `System` and I copy the tags from `Filter` icon to these `Filter-2` icons

issue: https://github.com/tabler/tabler-icons/issues/1384

<details>
<summary>Filter icons</summary>
<img width="910" height="1254" alt="image" src="https://github.com/user-attachments/assets/1bf3d9f2-65dc-43d2-939f-4382cf6080e6" />
</details>

<details>
<summary>Filter 2 icons</summary>
<img width="907" height="1102" alt="image" src="https://github.com/user-attachments/assets/06a43d8e-7c09-4d9e-9d41-3b9caca76400" />
</details>




