### PR TITLE
Fix ref types in icons-react

### DIFF
--- a/packages/icons-react/src/createReactComponent.ts
+++ b/packages/icons-react/src/createReactComponent.ts
@@ -8,7 +8,7 @@ const createReactComponent = (
   iconNamePascal: string,
   iconNode: IconNode,
 ) => {
-  const Component = forwardRef<Icon, IconProps>(
+  const Component = forwardRef<SVGSVGElement, IconProps>(
     (
       { color = 'currentColor', size = 24, stroke = 2, title, className, children, ...rest }: IconProps,
       ref,


### PR DESCRIPTION
`createReactComponent` incorrectly types its `forwardRef` call as reffing an `Icon` instance. That ref is then passed directly to an `svg` element, so instead, it should be typed as `SVGSVGElement`, as this is what will actually be reffed!