### PR TITLE
fix: export type path in react-native package

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": {
       "require": {
-        "types": "./dist/cjs/tabler-icons-react-native.d.cts",
+        "types": "./dist/tabler-icons-react-native.d.ts",
         "default": "./dist/cjs/tabler-icons-react-native.cjs"
       },
       "import": {


### PR DESCRIPTION
Fixes the following typescript error:

<img width="947" height="207" alt="Screenshot 2025-09-03 at 12 11 13 PM" src="https://github.com/user-attachments/assets/cb3ac083-cf69-458f-bad9-ffae4e17d3a8" />

The `types` file currently being referenced in the package under the `"."` does not exist. It looks like it was moved at some point but the reference wasn't updated. This fix just updates the path + files to the correct types file, which is also used by the `import` key right below this change.