### PR TITLE
Add icon `outline/option`

### DIFF
--- a/icons/outline/option.svg
+++ b/icons/outline/option.svg
@@ -1,0 +1,18 @@
+<!--
+category: Symbols
+tags: [apple, key, keyboard, option]
+version: "1.0"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14,6h5M19,18h-5l-5-12h-4"/>
+</svg>


### PR DESCRIPTION
Add Option (⌥) icon — `outline/option.svg`. 

Resolves issue #1423.
