### PR TITLE
Add JSDoc with previews in icons-react

### DIFF
--- a/.build/build-icons.mjs
+++ b/.build/build-icons.mjs
@@ -26,7 +26,7 @@ export const buildJsIcons = ({
 }) => {
   const DIST_DIR = path.resolve(PACKAGES_DIR, name);
   const aliases = getAliases(),
-    allIcons = getAllIcons(false, true);
+    allIcons = getAllIcons(true, true);
 
   let index = [];
   Object.entries(allIcons).forEach(([type, icons]) => {
@@ -77,6 +77,7 @@ export const buildJsIcons = ({
           type,
           name: iconName,
           namePascal: iconNamePascal,
+          svg: icon.content,
         }),
       );
     });

--- a/packages/icons-react/build.mjs
+++ b/packages/icons-react/build.mjs
@@ -6,18 +6,36 @@ import {
   buildIconsDynamicImport,
 } from '../../.build/build-icons.mjs';
 
-const componentTemplate = ({ type, name, namePascal, children }) => `\
+const componentTemplate = ({ type, name, namePascal, children, svg }) => {
+  const svgBase64 = Buffer.from(svg).toString('base64');
+  return `\
 import createReactComponent from '../createReactComponent';
 import { IconNode } from '../types';
 
 export const __iconNode: IconNode = ${JSON.stringify(children)}
 
+/**
+ * Icon${namePascal}
+ * @preview ![img](data:image/svg+xml;base64,${svgBase64}) - https://tabler.io/icons/icon/${name}
+ * @see https://docs.tabler.io/icons/libraries/react - Documentation
+ *
+ */
 const Icon${namePascal} = createReactComponent('${type}', '${name}', '${namePascal}', __iconNode);
 
 export default Icon${namePascal};`;
+};
 
-const indexItemTemplate = ({ name, namePascal }) =>
-  `export { default as Icon${namePascal} } from './Icon${namePascal}';`;
+const indexItemTemplate = ({ name, namePascal, svg }) => {
+  const svgBase64 = Buffer.from(svg).toString('base64');
+  return `\
+/**
+ * Icon${namePascal}
+ * @preview ![img](data:image/svg+xml;base64,${svgBase64}) - https://tabler.io/icons/icon/${name}
+ * @see https://docs.tabler.io/icons/libraries/react - Documentation
+ *
+ */
+export { default as Icon${namePascal} } from './Icon${namePascal}';`;
+};
 
 const aliasTemplate = ({ fromPascal, toPascal }) =>
   `export { default as Icon${fromPascal} } from './icons/Icon${toPascal}';\n`;


### PR DESCRIPTION
<img width="1836" height="660" alt="Screenshot 2026-02-06 at 1 19 59 PM" src="https://github.com/user-attachments/assets/7be5cbd8-0be7-404a-a178-d6e7fbde4779" />

This PR adds JSDoc annotations to the icons-react package so that people using it can see a preview of the icon, and links to the documentation, by hovering over the icon component in supported IDEs like VSCode. 

I added this for my own convenience and just wanted to share. I got the idea from a different icon library that uses this same technique: https://github.com/lucide-icons/lucide/pull/1424

AI Disclosure: This change was implemented with AI assistance (Claude Opus 4.6, Cursor Tab) and reviewed by me.

