### PR TITLE
fix(icons-react-native): add react-native-svg as peer dependency

### DIFF
--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -72,7 +72,8 @@
     "react-test-renderer": "18.2.0"
   },
   "peerDependencies": {
-    "react": ">= 16.5.1"
+    "react": ">= 16.5.1",
+    "react-native-svg": ">= 13.0.0"
   },
   "optionalDependencies": {}
 }

--- a/packages/icons-react-native/src/types.ts
+++ b/packages/icons-react-native/src/types.ts
@@ -1,4 +1,3 @@
-
 import { ForwardRefExoticComponent, ReactSVG, SVGProps } from 'react';
 import type { SvgProps } from 'react-native-svg';
 export * as NativeSvg from 'react-native-svg';


### PR DESCRIPTION
`react-native-svg` is imported directly in the distributed bundle via `src/types.ts`, but was not declared as a peer dependency.

This causes Metro bundler to fail when consumers install `@tabler/icons-react-native` without `react-native-svg` present in their project:

```
ERROR  Error: Unable to resolve module react-native-svg from ...\node_modules\.pnpm\@tabler+icons-react-native@3.37.1_react@19.1.0\node_modules\@tabler\icons-react-native\dist\esm\createReactNativeComponent.mjs: react-native-svg could not be found within the project or in these directories:
  ..\..\node_modules\.pnpm\@tabler+icons-react-native@3.37.1_react@19.1.0\node_modules
  ..\..\node_modules\.pnpm\node_modules
  ..\..\node_modules
   8 | import { forwardRef, createElement } from 'react';
   9 | import defaultAttributes, { childDefaultAttributes } from './defaultAttributes.mjs';
> 10 | import * as NativeSvg from 'react-native-svg';
     |                             ^
  11 |
  12 | const createReactNativeComponent = (type, iconName, iconNamePascal, iconNode) => {
  13 |   const Component = forwardRef(
```