### PR TITLE
New icon: outline/dragon

### DIFF
--- a/icons/outline/dragon.svg
+++ b/icons/outline/dragon.svg
@@ -1,0 +1,20 @@
+<!--
+tags: [animal, creature, living, organism, fantasy, monster]
+category: Animals
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M 10.706,8.8493 5,5.54802 3,12 6.5,10.0275 7,13 10.55488,11.6151"/>
+  <path d="m15 9c0 3.5 4 3 4 7 0 3-3 5-5.5 5s-6-0.5-6.5-5c2 2 6.5918 3.0433 7.5 1 1.0936-2.4605-4-3.4586-4-6.5 0-2.0616 0.5-2.5 1.8-3.2"/>
+  <path d="m18 6a3 3 270 1 0-3 3h5l1-3h-3"/>
+  <path d="m15 3h-8l5 3"/>
+</svg>


### PR DESCRIPTION
Adds `outline/dragon`

See https://github.com/tabler/tabler-icons/issues/1505.