### PR TITLE
docs: add yarn and pnpm installation alternatives to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 ## Installation
 
 ```
-npm install @tabler/icons --save
+npm install @tabler/icons --save ```  or  ``` yarn add @tabler/icons ```  or  ``` pnpm add @tabler/icons
 ```
 
 or just [download from GitHub](https://github.com/tabler/tabler-icons/releases).


### PR DESCRIPTION
The Installation section in README currently only shows `npm install @tabler/icons --save` without alternatives for other popular package managers.

This PR adds `yarn` and `pnpm` install commands as alternatives, making the documentation more helpful for developers who use those package managers.

**Changes:**
- Added `yarn add @tabler/icons` as an installation alternative
- Added `pnpm add @tabler/icons` as an installation alternative