### PR TITLE
Add sideEffects: false to icons-vue

### DIFF
--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -21,6 +21,7 @@
   "module": "./dist/esm/tabler-icons-vue.mjs",
   "types": "./dist/tabler-icons-vue.d.ts",
   "amdName": "TablerIconsVue",
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Add `sideEffects: false` to icons-vue package.json to allow tree-shaking.

Currently all icons are bundled regardless of which were actually imported, this change allows bundlers to remove unused icons.