### PR TITLE
Fixed icons: `outline/server`, `outline/server-bolt`

### DIFF
--- a/icons/outline/server-bolt.svg
+++ b/icons/outline/server-bolt.svg
@@ -15,7 +15,7 @@ unicode: "f320"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 7a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3" />
+  <path d="M3 7a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-2" />
   <path d="M15 20h-9a3 3 0 0 1 -3 -3v-2a3 3 0 0 1 3 -3h12" />
   <path d="M7 8v.01" />
   <path d="M7 16v.01" />

--- a/icons/outline/server.svg
+++ b/icons/outline/server.svg
@@ -15,7 +15,7 @@ unicode: "eb1f"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 7a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3" />
+  <path d="M3 7a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-2" />
   <path d="M3 15a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3l0 -2" />
   <path d="M7 8l0 .01" />
   <path d="M7 16l0 .01" />


### PR DESCRIPTION
Fixes #1527 by adding the missing `v-2` to the end of the path command.

This `v-2` command was present on `outline/server-2` and `outline/server-cog`, but was missing from `outline/server` and `outline/server-bolt`. This makes the `outline/server` and `outline/server-bolt` consistent with how the other server icons look.