### PR TITLE
fix: correct flip icon orientations

### DIFF
--- a/icons/outline/flip-horizontal.svg
+++ b/icons/outline/flip-horizontal.svg
@@ -15,7 +15,7 @@ unicode: "eaa7"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 12l18 0" />
-  <path d="M7 16l10 0l-10 5l0 -5" />
-  <path d="M7 8l10 0l-10 -5l0 5" />
+  <path d="M12 3l0 18" />
+  <path d="M16 7l0 10l5 0l-5 -10" />
+  <path d="M8 7l0 10l-5 0l5 -10" />
 </svg>

--- a/icons/outline/flip-vertical.svg
+++ b/icons/outline/flip-vertical.svg
@@ -15,7 +15,7 @@ unicode: "eaa8"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 3l0 18" />
-  <path d="M16 7l0 10l5 0l-5 -10" />
-  <path d="M8 7l0 10l-5 0l5 -10" />
+  <path d="M3 12l18 0" />
+  <path d="M7 16l10 0l-10 5l0 -5" />
+  <path d="M7 8l10 0l-10 -5l0 5" />
 </svg>

--- a/test/flip-icons.mjs
+++ b/test/flip-icons.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+const horizontal = fs.readFileSync('icons/outline/flip-horizontal.svg', 'utf8')
+const vertical = fs.readFileSync('icons/outline/flip-vertical.svg', 'utf8')
+
+assert.match(
+  horizontal,
+  /<path d="M12 3l0 18" \/>/,
+  'flip-horizontal should use a vertical mirror axis for left-right flipping',
+)
+assert.match(
+  vertical,
+  /<path d="M3 12l18 0" \/>/,
+  'flip-vertical should use a horizontal mirror axis for up-down flipping',
+)


### PR DESCRIPTION
Fixes tabler/tabler-icons#1537.

The `flip-horizontal` and `flip-vertical` source SVGs were using the opposite mirror-axis geometry for the behavior their names describe. This swaps only the path geometry between the two icons, leaving metadata, tags, unicode values, and filenames unchanged.

Verification:

- `node test/flip-icons.mjs` failed before the SVG swap, then passed after
- `pnpm run validate`
- `git diff --check`
