### PR TITLE
Add MCP SVG icon

### DIFF
--- a/icons/outline/mcp.svg
+++ b/icons/outline/mcp.svg
@@ -1,0 +1,19 @@
+<!--
+tags: [programming, coding, program, code, configuration, api, software, technical, developer, interface, opensource, mcp, model, context, protocol]
+category: Development
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3.2 11.3709L11.4967 3.07418C12.6423 1.92864 14.4996 1.92864 15.645 3.07418C16.7906 4.21971 16.7906 6.077 15.645 7.22254L9.37932 13.4883" />
+  <path d="M9.46575 13.4019L15.645 7.22254C16.7906 6.077 18.6479 6.077 19.7935 7.22254L19.8366 7.26575C20.9822 8.41129 20.9822 10.2686 19.8366 11.4141L12.333 18.9178C11.9512 19.2996 11.9512 19.9187 12.333 20.3005L13.8738 21.8413" />
+  <path d="M13.5709 5.14836L7.43478 11.2845C6.28924 12.43 6.28924 14.2873 7.43478 15.4329C8.58032 16.5783 10.4376 16.5783 11.5831 15.4329L17.7193 9.29671" />
+</svg>


### PR DESCRIPTION
Starting from the mcp logo, matched to the styles of Tabler