### PR TITLE
Add publishConfig for public access in all icon packages

### DIFF
--- a/packages/icons-astro/package.json
+++ b/packages/icons-astro/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-astro"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "amdName": "TablerIconsAstro",
   "main": "./dist/cjs/tabler-icons-astro.cjs",

--- a/packages/icons-eps/package.json
+++ b/packages/icons-eps/package.json
@@ -10,6 +10,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/codecalm"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm run clean && pnpm run copy:license && pnpm run build:icons",
     "build:icons": "node build.mjs",

--- a/packages/icons-pdf/package.json
+++ b/packages/icons-pdf/package.json
@@ -15,6 +15,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-pdf"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm run clean && pnpm run copy:license && pnpm run build:icons",
     "build:icons": "node build.mjs",

--- a/packages/icons-png/package.json
+++ b/packages/icons-png/package.json
@@ -15,6 +15,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-png"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm run clean && pnpm run copy:license && pnpm run build:icons",
     "build:icons": "node build.mjs",

--- a/packages/icons-preact/package.json
+++ b/packages/icons-preact/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-preact"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/cjs/tabler-icons-preact.cjs",
   "types": "./dist/tabler-icons-preact.d.ts",
   "module": "./dist/esm/tabler-icons-preact.mjs",

--- a/packages/icons-react-native/package.json
+++ b/packages/icons-react-native/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-react-native"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/cjs/tabler-icons-react-native.cjs",
   "types": "./dist/cjs/tabler-icons-react-native.d.cts",

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-react"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/cjs/tabler-icons-react.cjs",
   "module": "./dist/esm/tabler-icons-react.mjs",
   "types": "./dist/tabler-icons-react.d.ts",

--- a/packages/icons-solidjs/package.json
+++ b/packages/icons-solidjs/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-solidjs"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "type": "module",
   "amdName": "TablerIconsSolidjs",

--- a/packages/icons-sprite/package.json
+++ b/packages/icons-sprite/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git+https://github.com/tabler/tabler-icons.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "amdName": "TablerIconsSprite",
   "files": [

--- a/packages/icons-svelte-runes/package.json
+++ b/packages/icons-svelte-runes/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-svelte-runes"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "svelte": "./dist/tabler-icons-svelte-runes.js",
   "types": "./dist/tabler-icons-svelte-runes.d.ts",
   "type": "module",

--- a/packages/icons-svelte/package.json
+++ b/packages/icons-svelte/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-svelte"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "svelte": "./dist/tabler-icons-svelte.js",
   "types": "./dist/tabler-icons-svelte.d.ts",
   "type": "module",

--- a/packages/icons-vue/package.json
+++ b/packages/icons-vue/package.json
@@ -17,6 +17,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-vue"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/cjs/tabler-icons-vue.cjs",
   "module": "./dist/esm/tabler-icons-vue.mjs",
   "types": "./dist/tabler-icons-vue.d.ts",

--- a/packages/icons-webfont/package.json
+++ b/packages/icons-webfont/package.json
@@ -15,6 +15,9 @@
     "url": "git+https://github.com/tabler/tabler-icons.git",
     "directory": "packages/icons-webfont"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm run copy && pnpm run build:prepare && pnpm run build:webfont && pnpm run build:css",
     "build:prepare": "mkdir -p icons-outlined dist && rm -fdr dist/*",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git+https://github.com/tabler/tabler-icons.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "amdName": "TablerIcons",
   "exports": {
     "./*": [


### PR DESCRIPTION
This pull request updates the `package.json` files for all icon packages to add a `publishConfig` section with `"access": "public"`. This change ensures that when these packages are published to npm, they will be publicly accessible, which is important for open source distribution and for users to be able to install them without restrictions.

**Publishing configuration updates:**

* Added `"publishConfig": { "access": "public" }` to `package.json` for the following packages to ensure public npm publishing:
  - `icons`
  - `icons-astro`
  - `icons-eps`
  - `icons-pdf`
  - `icons-png`
  - `icons-preact`
  - `icons-react`
  - `icons-react-native`
  - `icons-solidjs`
  - `icons-sprite`
  - `icons-svelte`
  - `icons-svelte-runes`
  - `icons-vue`
  - `icons-webfont`