### PR TITLE
Added Memory SVG Icon

### DIFF
--- a/icons/outline/memory.svg
+++ b/icons/outline/memory.svg
@@ -1,0 +1,22 @@
+<!--
+tags: [ram, storage, computer, chip, hardware, technology, electronic, gadget, equipment]
+category: Devices
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 10v2" />
+  <path d="M16 10v2" />
+  <path d="M2 7a1 1 0 011-1h18a1 1 0 011 1v1.75a.75.75 0 01-.75.75.75.75 0 00-.75.75v1.5a.75.75 0 00.75.75.75.75 0 01.75.75V15a1 1 0 01-1 1H3a1 1 0 01-1-1v-1.75a.75.75 0 01.75-.75.75.75 0 00.75-.75v-1.5a.75.75 0 00-.75-.75.75.75 0 01-.75-.75z" />
+  <path d="M8 10v2" />
+  <rect x="12" y="16" width="8" height="2" fill="currentColor" />
+  <rect x="4" y="16" width="5" height="2" fill="currentColor" />
+</svg>


### PR DESCRIPTION
Hi, tabler icons was missing this icon for so long so I made it, this icon was mentionned in https://github.com/tabler/tabler-icons/issues/927, https://github.com/tabler/tabler-icons/issues/1135, https://github.com/tabler/tabler-icons/issues/457 and https://github.com/tabler/tabler-icons/issues/372.

If there is any issues, I'm ready to update this icon to make it suitable.

<img width="736" height="424" alt="Stroke width" src="https://github.com/user-attachments/assets/7a219fec-e847-4012-a6ec-19a48c9e24c6" />
<img width="320" height="376" alt="Spacings" src="https://github.com/user-attachments/assets/4fddaf38-2e1b-45bf-baa5-6ee0c2ffdd7c" />
