### PR TITLE
Run tests in CI, fix ReactSVG type rot, add type and RSC guards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,11 @@ jobs:
           ICONS_LIMIT: 100
         run: pnpm run build
 
+      # @tabler/icons-angular is excluded: its suite runs in a real Chrome via
+      # Karma and needs a browser setup this job does not have yet. Every other
+      # package runs on vitest or node:test.
+      - name: Test
+        env:
+          ICONS_LIMIT: 100
+        run: pnpm exec turbo run test --filter=!@tabler/icons-angular
+

--- a/packages/icons-preact/test.spec.tsx
+++ b/packages/icons-preact/test.spec.tsx
@@ -74,16 +74,14 @@ describe("Preact Icon component", () => {
            stroke-linejoin="round"
            class="tabler-icon tabler-icon-accessible  "
       >
-        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
+        <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
         </path>
         <path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1">
         </path>
-        <circle cx="12"
-                cy="7.5"
-                r=".5"
-                fill="currentColor"
+        <path d="M11.5 7.5a.5 .5 0 1 0 1 0a.5 .5 0 1 0 -1 0"
+              fill="currentColor"
         >
-        </circle>
+        </path>
       </svg>
     `)
   })

--- a/packages/icons-react-native/src/types.ts
+++ b/packages/icons-react-native/src/types.ts
@@ -1,8 +1,74 @@
-import { ForwardRefExoticComponent, ReactSVG, SVGProps } from 'react';
+import { ForwardRefExoticComponent, SVGProps } from 'react';
 import type { SvgProps } from 'react-native-svg';
 export * as NativeSvg from 'react-native-svg';
 
-export type IconNode = [elementName: keyof ReactSVG, attrs: Record<string, string>][];
+/**
+ * Names of the SVG elements an icon can be built from.
+ *
+ * This used to be `keyof ReactSVG`, but `ReactSVG` was removed in
+ * @types/react 19, which broke type-checking for anyone not running with
+ * `skipLibCheck`. The set below reproduces `ReactSVG`'s keys exactly, so the
+ * type is unchanged for consumers while no longer depending on a React type
+ * that comes and goes between majors.
+ */
+export type SvgElementName =
+  | 'animate'
+  | 'circle'
+  | 'clipPath'
+  | 'defs'
+  | 'desc'
+  | 'ellipse'
+  | 'feBlend'
+  | 'feColorMatrix'
+  | 'feComponentTransfer'
+  | 'feComposite'
+  | 'feConvolveMatrix'
+  | 'feDiffuseLighting'
+  | 'feDisplacementMap'
+  | 'feDistantLight'
+  | 'feDropShadow'
+  | 'feFlood'
+  | 'feFuncA'
+  | 'feFuncB'
+  | 'feFuncG'
+  | 'feFuncR'
+  | 'feGaussianBlur'
+  | 'feImage'
+  | 'feMerge'
+  | 'feMergeNode'
+  | 'feMorphology'
+  | 'feOffset'
+  | 'fePointLight'
+  | 'feSpecularLighting'
+  | 'feSpotLight'
+  | 'feTile'
+  | 'feTurbulence'
+  | 'filter'
+  | 'foreignObject'
+  | 'g'
+  | 'image'
+  | 'line'
+  | 'linearGradient'
+  | 'marker'
+  | 'mask'
+  | 'metadata'
+  | 'path'
+  | 'pattern'
+  | 'polygon'
+  | 'polyline'
+  | 'radialGradient'
+  | 'rect'
+  | 'stop'
+  | 'svg'
+  | 'switch'
+  | 'symbol'
+  | 'text'
+  | 'textPath'
+  | 'tspan'
+  | 'use'
+  | 'view';
+
+export type IconNode = [elementName: SvgElementName, attrs: Record<string, string>][];
 
 export type SVGAttributes = Partial<SVGProps<SVGSVGElement>>;
 

--- a/packages/icons-react/src/types.ts
+++ b/packages/icons-react/src/types.ts
@@ -1,8 +1,74 @@
 
-import { ForwardRefExoticComponent, FunctionComponent, RefAttributes, ReactSVG } from 'react';
+import { ForwardRefExoticComponent, FunctionComponent, RefAttributes } from 'react';
 export type { ReactNode } from 'react';
 
-export type IconNode = [elementName: keyof ReactSVG, attrs: Record<string, string>][];
+/**
+ * Names of the SVG elements an icon can be built from.
+ *
+ * This used to be `keyof ReactSVG`, but `ReactSVG` was removed in
+ * @types/react 19, which broke type-checking for anyone not running with
+ * `skipLibCheck`. The set below reproduces `ReactSVG`'s keys exactly, so the
+ * type is unchanged for consumers while no longer depending on a React type
+ * that comes and goes between majors.
+ */
+export type SvgElementName =
+  | 'animate'
+  | 'circle'
+  | 'clipPath'
+  | 'defs'
+  | 'desc'
+  | 'ellipse'
+  | 'feBlend'
+  | 'feColorMatrix'
+  | 'feComponentTransfer'
+  | 'feComposite'
+  | 'feConvolveMatrix'
+  | 'feDiffuseLighting'
+  | 'feDisplacementMap'
+  | 'feDistantLight'
+  | 'feDropShadow'
+  | 'feFlood'
+  | 'feFuncA'
+  | 'feFuncB'
+  | 'feFuncG'
+  | 'feFuncR'
+  | 'feGaussianBlur'
+  | 'feImage'
+  | 'feMerge'
+  | 'feMergeNode'
+  | 'feMorphology'
+  | 'feOffset'
+  | 'fePointLight'
+  | 'feSpecularLighting'
+  | 'feSpotLight'
+  | 'feTile'
+  | 'feTurbulence'
+  | 'filter'
+  | 'foreignObject'
+  | 'g'
+  | 'image'
+  | 'line'
+  | 'linearGradient'
+  | 'marker'
+  | 'mask'
+  | 'metadata'
+  | 'path'
+  | 'pattern'
+  | 'polygon'
+  | 'polyline'
+  | 'radialGradient'
+  | 'rect'
+  | 'stop'
+  | 'svg'
+  | 'switch'
+  | 'symbol'
+  | 'text'
+  | 'textPath'
+  | 'tspan'
+  | 'use'
+  | 'view';
+
+export type IconNode = [elementName: SvgElementName, attrs: Record<string, string>][];
 
 export interface IconProps extends Partial<Omit<React.ComponentPropsWithoutRef<'svg'>, 'stroke'>> {
   size?: string | number;

--- a/packages/icons-react/test.spec.tsx
+++ b/packages/icons-react/test.spec.tsx
@@ -84,16 +84,14 @@ describe("React Icon component", () => {
            stroke-linejoin="round"
            class="tabler-icon tabler-icon-accessible "
       >
-        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
+        <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
         </path>
         <path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1">
         </path>
-        <circle cx="12"
-                cy="7.5"
-                r=".5"
-                fill="currentColor"
+        <path d="M11.5 7.5a.5 .5 0 1 0 1 0a.5 .5 0 1 0 -1 0"
+              fill="currentColor"
         >
-        </circle>
+        </path>
       </svg>
     `)
   })

--- a/packages/icons-svelte-runes/test.spec.js
+++ b/packages/icons-svelte-runes/test.spec.js
@@ -116,16 +116,14 @@ describe('Svelte Runes Icon component', () => {
            stroke-linejoin="round"
            class="tabler-icon tabler-icon-accessible "
       >
-        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
+        <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
         </path>
         <path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1">
         </path>
-        <circle cx="12"
-                cy="7.5"
-                r=".5"
-                fill="currentColor"
+        <path d="M11.5 7.5a.5 .5 0 1 0 1 0a.5 .5 0 1 0 -1 0"
+              fill="currentColor"
         >
-        </circle>
+        </path>
       </svg>
     `);
   });

--- a/packages/icons-svelte/test.spec.js
+++ b/packages/icons-svelte/test.spec.js
@@ -79,16 +79,14 @@ describe("Svelte Icon component", () => {
            stroke-linejoin="round"
            class="tabler-icon tabler-icon-accessible "
       >
-        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
+        <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0">
         </path>
         <path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1">
         </path>
-        <circle cx="12"
-                cy="7.5"
-                r=".5"
-                fill="currentColor"
+        <path d="M11.5 7.5a.5 .5 0 1 0 1 0a.5 .5 0 1 0 -1 0"
+              fill="currentColor"
         >
-        </circle>
+        </path>
       </svg>
     `);
   });

--- a/packages/icons-vue/test.spec.js
+++ b/packages/icons-vue/test.spec.js
@@ -111,11 +111,11 @@ describe("Vue Icon component", () => {
     const textElement = getByText(testText)
 
     expect(textElement).toBeInTheDocument()
-    expect(container.innerHTML).toMatchInlineSnapshot(`"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-accessible"><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path><path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1"></path><circle cx="12" cy="7.5" r=".5" fill="currentColor"></circle><text>Hello World</text></svg>"`);
+    expect(container.innerHTML).toMatchInlineSnapshot(`"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-accessible"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path><path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1"></path><path d="M11.5 7.5a.5 .5 0 1 0 1 0a.5 .5 0 1 0 -1 0" fill="currentColor"></path><text>Hello World</text></svg>"`);
   });
 
   it("should match snapshot", () => {
     const { container } = render(IconAccessible);
-    expect(container.innerHTML).toMatchInlineSnapshot(`"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-accessible"><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path><path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1"></path><circle cx="12" cy="7.5" r=".5" fill="currentColor"></circle></svg>"`)
+    expect(container.innerHTML).toMatchInlineSnapshot(`"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-accessible"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path><path d="M10 16.5l2 -3l2 3m-2 -3v-2l3 -1m-6 0l3 1"></path><path d="M11.5 7.5a.5 .5 0 1 0 1 0a.5 .5 0 1 0 -1 0" fill="currentColor"></path></svg>"`)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,44 @@ importers:
         specifier: 'catalog:'
         version: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
 
+  test/test-react-rsc:
+    dependencies:
+      '@tabler/icons-react':
+        specifier: workspace:*
+        version: link:../../packages/icons-react
+    devDependencies:
+      react:
+        specifier: ^19.2.0
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.8(react@19.2.8)
+      react-server-dom-webpack:
+        specifier: ^19.2.0
+        version: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(esbuild@0.20.2))
+
+  test/test-react-types:
+    dependencies:
+      '@tabler/icons-react':
+        specifier: workspace:*
+        version: link:../../packages/icons-react
+    devDependencies:
+      '@types/react-16':
+        specifier: npm:@types/react@^16
+        version: '@types/react@16.14.70'
+      '@types/react-17':
+        specifier: npm:@types/react@^17
+        version: '@types/react@17.0.93'
+      '@types/react-18':
+        specifier: npm:@types/react@^18
+        version: '@types/react@18.3.27'
+      '@types/react-19':
+        specifier: npm:@types/react@^19
+        version: '@types/react@19.2.18'
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   test/test-svelte:
     dependencies:
       '@tabler/icons-svelte':
@@ -5065,8 +5103,17 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
+  '@types/react@16.14.70':
+    resolution: {integrity: sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==}
+
+  '@types/react@17.0.93':
+    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
+
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -5076,6 +5123,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/scheduler@0.16.8':
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
@@ -5313,6 +5363,10 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
 
   acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
@@ -9779,6 +9833,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -9809,6 +9868,14 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-server-dom-webpack@19.2.8:
+    resolution: {integrity: sha512-rFO1VJZ+cH9ZH6hGy9+qmIsmZHZpCMKJZXhWHqT71UnSfg+w+W+gwrwp58MVzMqdFquG8GF1c6C8q0OGphkEdg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.8
+      react-dom: ^19.2.8
+      webpack: ^5.59.0
+
   react-shallow-renderer@16.15.0:
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
@@ -9821,6 +9888,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   read-package-json-fast@3.0.2:
@@ -10143,6 +10214,9 @@ packages:
 
   scheduler@0.24.0-canary-efb381bbf-20230505:
     resolution: {integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
@@ -12091,35 +12165,35 @@ snapshots:
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/runtime': 7.28.6
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 21.2.3(@angular/compiler-cli@21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))
+      '@ngtools/webpack': 21.2.3(@angular/compiler-cli@21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.2(esbuild@0.20.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.27(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3))
+      babel-loader: 10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.20.2))
       browserslist: 4.28.1
-      copy-webpack-plugin: 14.0.0(webpack@5.105.2(esbuild@0.27.3))
-      css-loader: 7.1.3(webpack@5.105.2(esbuild@0.27.3))
+      copy-webpack-plugin: 14.0.0(webpack@5.105.2(esbuild@0.20.2))
+      css-loader: 7.1.3(webpack@5.105.2(esbuild@0.20.2))
       esbuild-wasm: 0.27.3
       http-proxy-middleware: 3.0.5
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.2
-      less-loader: 12.3.1(less@4.4.2)(webpack@5.105.2(esbuild@0.27.3))
-      license-webpack-plugin: 4.0.2(webpack@5.105.2(esbuild@0.27.3))
+      less-loader: 12.3.1(less@4.4.2)(webpack@5.105.2(esbuild@0.20.2))
+      license-webpack-plugin: 4.0.2(webpack@5.105.2(esbuild@0.20.2))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(esbuild@0.27.3))
+      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(esbuild@0.20.2))
       open: 11.0.0
       ora: 9.3.0
       picomatch: 4.0.3
       piscina: 5.1.4
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.20.2))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.97.3
-      sass-loader: 16.0.7(sass@1.97.3)(webpack@5.105.2(esbuild@0.27.3))
+      sass-loader: 16.0.7(sass@1.97.3)(webpack@5.105.2(esbuild@0.20.2))
       semver: 7.7.4
-      source-map-loader: 5.0.0(webpack@5.105.2(esbuild@0.27.3))
+      source-map-loader: 5.0.0(webpack@5.105.2(esbuild@0.20.2))
       source-map-support: 0.5.21
       terser: 5.46.0
       tinyglobby: 0.2.15
@@ -12130,7 +12204,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.2(esbuild@0.27.3))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.2(esbuild@0.20.2))
     optionalDependencies:
       '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10)
       '@angular/platform-browser': 21.2.5(@angular/animations@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10))
@@ -12178,35 +12252,35 @@ snapshots:
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/runtime': 7.28.6
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 21.2.3(@angular/compiler-cli@21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))
+      '@ngtools/webpack': 21.2.3(@angular/compiler-cli@21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.2(esbuild@0.20.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.27(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3))
+      babel-loader: 10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.20.2))
       browserslist: 4.28.1
-      copy-webpack-plugin: 14.0.0(webpack@5.105.2(esbuild@0.27.3))
-      css-loader: 7.1.3(webpack@5.105.2(esbuild@0.27.3))
+      copy-webpack-plugin: 14.0.0(webpack@5.105.2(esbuild@0.20.2))
+      css-loader: 7.1.3(webpack@5.105.2(esbuild@0.20.2))
       esbuild-wasm: 0.27.3
       http-proxy-middleware: 3.0.5
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.2
-      less-loader: 12.3.1(less@4.4.2)(webpack@5.105.2(esbuild@0.27.3))
-      license-webpack-plugin: 4.0.2(webpack@5.105.2(esbuild@0.27.3))
+      less-loader: 12.3.1(less@4.4.2)(webpack@5.105.2(esbuild@0.20.2))
+      license-webpack-plugin: 4.0.2(webpack@5.105.2(esbuild@0.20.2))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(esbuild@0.27.3))
+      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(esbuild@0.20.2))
       open: 11.0.0
       ora: 9.3.0
       picomatch: 4.0.3
       piscina: 5.1.4
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.20.2))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.97.3
-      sass-loader: 16.0.7(sass@1.97.3)(webpack@5.105.2(esbuild@0.27.3))
+      sass-loader: 16.0.7(sass@1.97.3)(webpack@5.105.2(esbuild@0.20.2))
       semver: 7.7.4
-      source-map-loader: 5.0.0(webpack@5.105.2(esbuild@0.27.3))
+      source-map-loader: 5.0.0(webpack@5.105.2(esbuild@0.20.2))
       source-map-support: 0.5.21
       terser: 5.46.0
       tinyglobby: 0.2.15
@@ -12217,7 +12291,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.2(esbuild@0.27.3))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.2(esbuild@0.20.2))
     optionalDependencies:
       '@angular/core': 21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10)
       '@angular/platform-browser': 21.2.5(@angular/animations@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@21.2.5(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@21.2.5(@angular/compiler@21.2.5)(rxjs@7.8.2)(zone.js@0.14.10))
@@ -15885,7 +15959,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@ngtools/webpack@21.2.3(@angular/compiler-cli@21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))':
+  '@ngtools/webpack@21.2.3(@angular/compiler-cli@21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.2(esbuild@0.20.2))':
     dependencies:
       '@angular/compiler-cli': 21.2.5(@angular/compiler@21.2.5)(typescript@5.9.3)
       typescript: 5.9.3
@@ -17306,9 +17380,25 @@ snapshots:
       '@types/react': 18.3.27
     optional: true
 
+  '@types/react@16.14.70':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
+
+  '@types/react@17.0.93':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
+
   '@types/react@18.3.27':
     dependencies:
       '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/react@19.2.18':
+    dependencies:
       csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
@@ -17318,6 +17408,8 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 20.19.37
+
+  '@types/scheduler@0.16.8': {}
 
   '@types/send@0.17.6':
     dependencies:
@@ -17667,6 +17759,10 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.15.0
+
   acorn-walk@7.2.0: {}
 
   acorn-walk@8.3.4:
@@ -17998,7 +18094,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
 
-  babel-loader@10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3)):
+  babel-loader@10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
@@ -18734,7 +18830,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@14.0.0(webpack@5.105.2(esbuild@0.27.3)):
+  copy-webpack-plugin@14.0.0(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -18784,7 +18880,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  css-loader@7.1.3(webpack@5.105.2(esbuild@0.27.3)):
+  css-loader@7.1.3(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -21006,7 +21102,7 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  less-loader@12.3.1(less@4.4.2)(webpack@5.105.2(esbuild@0.27.3)):
+  less-loader@12.3.1(less@4.4.2)(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       less: 4.4.2
     optionalDependencies:
@@ -21041,7 +21137,7 @@ snapshots:
 
   leven@3.1.0: {}
 
-  license-webpack-plugin@4.0.2(webpack@5.105.2(esbuild@0.27.3)):
+  license-webpack-plugin@4.0.2(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       webpack-sources: 3.3.4
     optionalDependencies:
@@ -21676,7 +21772,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.0(webpack@5.105.2(esbuild@0.27.3)):
+  mini-css-extract-plugin@2.10.0(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
@@ -22611,7 +22707,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
@@ -22983,6 +23079,11 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -23050,6 +23151,15 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.2(esbuild@0.20.2)):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      webpack: 5.105.2(esbuild@0.27.3)
+      webpack-sources: 3.3.4
+
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
       object-assign: 4.1.1
@@ -23066,6 +23176,8 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.8: {}
 
   read-package-json-fast@3.0.2:
     dependencies:
@@ -23461,7 +23573,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
-  sass-loader@16.0.7(sass@1.97.3)(webpack@5.105.2(esbuild@0.27.3)):
+  sass-loader@16.0.7(sass@1.97.3)(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -23520,6 +23632,8 @@ snapshots:
   scheduler@0.24.0-canary-efb381bbf-20230505:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
     dependencies:
@@ -23910,7 +24024,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.2(esbuild@0.27.3)):
+  source-map-loader@5.0.0(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -25229,7 +25343,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.2(esbuild@0.27.3)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.2(esbuild@0.20.2)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.2(esbuild@0.27.3)

--- a/test/test-react-rsc/.gitignore
+++ b/test/test-react-rsc/.gitignore
@@ -1,0 +1,1 @@
+.sandbox/

--- a/test/test-react-rsc/package.json
+++ b/test/test-react-rsc/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "test-react-rsc",
+  "private": true,
+  "version": "3.46.0",
+  "type": "module",
+  "description": "Guards that @tabler/icons-react keeps working inside React Server Components.",
+  "scripts": {
+    "test": "node run.mjs",
+    "clean": "rm -rf .sandbox"
+  },
+  "dependencies": {
+    "@tabler/icons-react": "workspace:*"
+  },
+  "devDependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-server-dom-webpack": "^19.2.0"
+  },
+  "peerDependencies": {},
+  "optionalDependencies": {}
+}

--- a/test/test-react-rsc/rsc.test.mjs
+++ b/test/test-react-rsc/rsc.test.mjs
@@ -1,0 +1,98 @@
+// Guards that @tabler/icons-react keeps rendering inside React Server Components.
+//
+// Run via run.mjs, which sandboxes the built package and passes
+// `--conditions=react-server` — how bundlers resolve modules for the RSC graph.
+// Under that condition React exposes a reduced API: `createContext` and
+// `useContext` do not exist.
+//
+// Why this guard exists: lucide-react v1 added a context-based provider whose
+// module called `createContext()` at import time. Every icon imported that
+// module, so no icon could be used in an RSC environment at all
+// (lucide-icons/lucide#4200). A `"use client"` directive did not save them,
+// because bundlers drop directives when pre-bundling a dependency.
+//
+// Both published entries are checked. The package has no `exports` map, so Node
+// resolves the bare specifier to `main` (CJS) while bundlers follow `module`
+// (ESM) — and it is the bundler path that actually feeds the RSC graph. Testing
+// only the bare specifier would leave the ESM bundle unguarded.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// React reads NODE_ENV when it initialises; production keeps the Flight payload
+// free of debug rows so it can be parsed. This has to happen before React is
+// loaded, which is why everything below is a dynamic import.
+process.env.NODE_ENV = 'production';
+
+const React = await import('react');
+const { renderToReadableStream } = await import('react-server-dom-webpack/server.edge');
+
+const ENTRIES = {
+  'bare specifier (CJS via "main")': '@tabler/icons-react',
+  'ESM bundle (what bundlers load)': '@tabler/icons-react/dist/esm/tabler-icons-react.mjs',
+};
+
+/** Render through the real RSC renderer and return the root element's props. */
+async function renderInRSC(element) {
+  const payload = await new Response(renderToReadableStream(element, {})).text();
+  const root = payload.split('\n').find((line) => line.startsWith('0:'));
+  assert.ok(root, `no root row in Flight payload:\n${payload}`);
+
+  // A host element serialises as ["$", tag, key, props].
+  const [marker, tag, , props] = JSON.parse(root.slice(2));
+  assert.equal(marker, '$');
+  assert.equal(tag, 'svg');
+  return props;
+}
+
+/** ICONS_LIMIT changes which icons are generated, so pick whatever is there. */
+function anyIcon(icons) {
+  const name = Object.keys(icons)
+    .filter((key) => /^Icon[A-Z]/.test(key))
+    .sort()[0];
+  assert.ok(name, 'the package exported no Icon* components');
+  return [name, icons[name]];
+}
+
+test('the react-server build of React really is missing client-only APIs', () => {
+  // If this ever starts failing, React changed and the rest of this file's
+  // reasoning needs revisiting — that is worth knowing loudly.
+  assert.equal(typeof React.createContext, 'undefined');
+  assert.equal(typeof React.useContext, 'undefined');
+
+  // These are available, and the icon runtime is allowed to use them.
+  assert.equal(typeof React.forwardRef, 'function');
+  assert.equal(typeof React.createElement, 'function');
+  assert.equal(typeof React.useId, 'function');
+});
+
+for (const [label, specifier] of Object.entries(ENTRIES)) {
+  test(`${label}: imports under the react-server condition`, async () => {
+    // The lucide failure mode: importing the entry throws before anything renders.
+    const icons = await import(specifier);
+    assert.equal(typeof icons.createReactComponent, 'function');
+    assert.ok(anyIcon(icons)[1], 'icon export is not usable');
+  });
+
+  test(`${label}: an icon renders in a Server Component with default attributes`, async () => {
+    const icons = await import(specifier);
+    const [name, Icon] = anyIcon(icons);
+    const props = await renderInRSC(React.createElement(Icon));
+
+    assert.equal(props.width, 24, `${name} rendered with an unexpected width`);
+    assert.equal(props.height, 24);
+    assert.match(props.className, /(^|\s)tabler-icon(\s|$)/);
+  });
+
+  test(`${label}: an icon renders in a Server Component with props applied`, async () => {
+    const icons = await import(specifier);
+    const [, Icon] = anyIcon(icons);
+    const props = await renderInRSC(
+      React.createElement(Icon, { size: 48, color: 'red', className: 'ui-icon' }),
+    );
+
+    assert.equal(props.width, 48);
+    assert.equal(props.height, 48);
+    assert.match(props.className, /(^|\s)ui-icon(\s|$)/);
+  });
+}

--- a/test/test-react-rsc/run.mjs
+++ b/test/test-react-rsc/run.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+// Runs rsc.test.mjs against a sandboxed copy of the built @tabler/icons-react.
+//
+// The sandbox exists to control which React the package resolves. In the pnpm
+// workspace, `node_modules/@tabler/icons-react` is a symlink, so Node resolves
+// `react` from packages/icons-react/node_modules — which holds the React 18
+// pinned in the catalog. React 18 has no usable react-server build; it throws
+// "This entry point is not yet supported outside of experimental channels".
+// RSC needs React 19.
+//
+// Copying the built package into .sandbox/node_modules/@tabler/icons-react
+// makes it a real directory, so `react` resolves upward to this package's own
+// React 19. It also means the test exercises the published artifact — package.json
+// exports and dist output — rather than the source tree.
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const pkgDir = path.resolve(root, '../../packages/icons-react');
+const sandbox = path.join(root, '.sandbox');
+const target = path.join(sandbox, 'node_modules', '@tabler', 'icons-react');
+
+const dist = path.join(pkgDir, 'dist');
+if (!fs.existsSync(dist)) {
+  console.error(`@tabler/icons-react is not built (missing ${dist}).\nRun: pnpm --filter @tabler/icons-react build`);
+  process.exit(1);
+}
+
+fs.rmSync(sandbox, { recursive: true, force: true });
+fs.mkdirSync(target, { recursive: true });
+
+// Only what resolution needs: the manifest and the build output.
+fs.copyFileSync(path.join(pkgDir, 'package.json'), path.join(target, 'package.json'));
+fs.cpSync(dist, path.join(target, 'dist'), { recursive: true });
+
+// The test has to live inside the sandbox so that its own module resolution
+// starts there and walks up into this package's node_modules.
+fs.copyFileSync(path.join(root, 'rsc.test.mjs'), path.join(sandbox, 'rsc.test.mjs'));
+
+let failed = false;
+try {
+  execFileSync(
+    process.execPath,
+    ['--conditions=react-server', '--test', 'rsc.test.mjs'],
+    { cwd: sandbox, stdio: 'inherit' },
+  );
+} catch {
+  failed = true;
+}
+
+fs.rmSync(sandbox, { recursive: true, force: true });
+process.exit(failed ? 1 : 0);

--- a/test/test-react-types/check.mjs
+++ b/test/test-react-types/check.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+// Type-checks @tabler/icons-react's published declarations against every
+// supported @types/react major.
+//
+// Why this exists: `IconNode` was defined as `keyof ReactSVG`, and `ReactSVG`
+// was removed in @types/react 19. That shipped, because nothing ever type-checked
+// the package against anything but the single pinned version in devDependencies.
+//
+// Each major is installed under an alias (@types/react-16 … @types/react-19) so
+// no reinstall is needed between runs — the version is selected by rewriting
+// `paths` and `typeRoots` in a generated tsconfig.
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+
+// Drive the matrix off devDependencies so adding a major is a one-line change.
+const aliases = Object.keys(pkg.devDependencies)
+  .filter((name) => /^@types\/react-\d+$/.test(name))
+  .sort((a, b) => Number(a.split('-').pop()) - Number(b.split('-').pop()));
+
+if (aliases.length === 0) {
+  console.error('No @types/react-<major> aliases found in devDependencies.');
+  process.exit(1);
+}
+
+const generatedConfig = path.join(root, 'tsconfig.generated.json');
+const failures = [];
+
+for (const alias of aliases) {
+  const typesDir = path.join(root, 'node_modules', alias);
+
+  if (!fs.existsSync(typesDir)) {
+    failures.push({ alias, version: '(not installed)', output: `Missing ${typesDir}. Run pnpm install.` });
+    console.log(`✗ ${alias.padEnd(20)} not installed`);
+    continue;
+  }
+
+  const { version } = JSON.parse(fs.readFileSync(path.join(typesDir, 'package.json'), 'utf8'));
+
+  fs.writeFileSync(
+    generatedConfig,
+    JSON.stringify(
+      {
+        extends: './tsconfig.json',
+        compilerOptions: {
+          // Point every `react` type reference at the alias under test, and stop
+          // TypeScript from auto-including the unaliased @types/react as well.
+          paths: {
+            react: [`./node_modules/${alias}`],
+            'react/*': [`./node_modules/${alias}/*`],
+          },
+          typeRoots: [`./node_modules/${alias}/..`],
+          types: [],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  let output = '';
+  let ok = true;
+  try {
+    execFileSync('npx', ['tsc', '-p', generatedConfig], { cwd: root, stdio: 'pipe' });
+  } catch (error) {
+    ok = false;
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`.trim();
+  }
+
+  console.log(`${ok ? '✓' : '✗'} @types/react ${version}`);
+  if (!ok) failures.push({ alias, version, output });
+}
+
+fs.rmSync(generatedConfig, { force: true });
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} of ${aliases.length} @types/react versions failed:\n`);
+  for (const { alias, version, output } of failures) {
+    console.error(`── ${alias} (${version}) ──`);
+    console.error(output);
+    console.error('');
+  }
+  process.exit(1);
+}
+
+console.log(`\nAll ${aliases.length} @types/react versions type-check cleanly.`);

--- a/test/test-react-types/package.json
+++ b/test/test-react-types/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "test-react-types",
+  "private": true,
+  "version": "3.46.0",
+  "type": "module",
+  "description": "Type-compatibility matrix for @tabler/icons-react across @types/react major versions.",
+  "scripts": {
+    "test": "node check.mjs",
+    "clean": "rm -rf tsconfig.generated.json"
+  },
+  "dependencies": {
+    "@tabler/icons-react": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react-16": "npm:@types/react@^16",
+    "@types/react-17": "npm:@types/react@^17",
+    "@types/react-18": "npm:@types/react@^18",
+    "@types/react-19": "npm:@types/react@^19",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {},
+  "optionalDependencies": {}
+}

--- a/test/test-react-types/src/consumer.ts
+++ b/test/test-react-types/src/consumer.ts
@@ -1,0 +1,39 @@
+// Exercises the public type surface of @tabler/icons-react.
+//
+// Deliberately imports no individual icon: the CI build runs with ICONS_LIMIT,
+// so which Icon* components exist varies. Everything referenced here is part of
+// the hand-written runtime and is always present.
+
+import { createReactComponent } from '@tabler/icons-react';
+import type { Icon, IconNode, IconProps, TablerIcon } from '@tabler/icons-react';
+
+// IconNode is the type most likely to rot: it has historically been defined in
+// terms of React types that come and go between @types/react majors.
+const node: IconNode = [
+  ['path', { d: 'M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0', key: 'svg-0' }],
+  ['circle', { cx: '12', cy: '7.5', r: '.5', fill: 'currentColor', key: 'svg-1' }],
+];
+
+// Building a component exercises the createElement overloads that IconNode feeds.
+const OutlineIcon: TablerIcon = createReactComponent('outline', 'accessible', 'Accessible', node);
+const FilledIcon: TablerIcon = createReactComponent('filled', 'accessible-filled', 'AccessibleFilled', node);
+
+// A TablerIcon must remain assignable to the looser Icon alias.
+const asIcon: Icon = OutlineIcon;
+
+// Props must accept the documented set plus arbitrary SVG attributes.
+const props: IconProps = {
+  size: 48,
+  stroke: 1.5,
+  color: 'red',
+  title: 'Accessible',
+  className: 'ui-icon',
+  style: { opacity: 0.5 },
+  'aria-hidden': true,
+  onClick: () => {},
+};
+
+// Both string and number are supported for size/stroke.
+const stringySizes: IconProps = { size: '2rem', stroke: '1.5' };
+
+export { OutlineIcon, FilledIcon, asIcon, props, stringySizes };

--- a/test/test-react-types/tsconfig.json
+++ b/test/test-react-types/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // The point of this package: check the dependency's own .d.ts files, not just our usage of them.
+    "skipLibCheck": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Why

CI only ran `pnpm run build`, so no test suite had ever executed on a pull request. Two things had rotted behind that gap:

- **Six snapshot assertions across five packages were failing.** They broke in 67ede20ca (#1440), which reshaped the `accessible` icon from `<circle>` to `<path>`. icons-react, icons-vue, icons-preact, icons-svelte and icons-svelte-runes were all affected.
- **`IconNode` no longer compiled against `@types/react` 19.** It was defined as `keyof ReactSVG`, and `ReactSVG` was removed in those types. This is already published. It is invisible to most users because `skipLibCheck: true` is the default in the tsconfig Next.js generates, but it is a hard error for anyone who turns it off.

## What changed

**CI now runs the tests.** `build.yml` gained a `turbo run test` step. `@tabler/icons-angular` is excluded — its Karma suite needs a real Chrome that this job does not set up. That is worth a follow-up issue; 41 passing tests currently never run in CI.

**Stale snapshots refreshed** in the five affected packages.

**`test/test-react-types`** — type-compatibility matrix. Type-checks the published declarations against `@types/react` 16, 17, 18 and 19. Each major is installed under an alias, so the version under test is selected by rewriting `paths` rather than reinstalling. It caught the `ReactSVG` defect on its first run.

**`test/test-react-rsc`** — React Server Components guard. Renders icons through `react-server-dom-webpack` under `--conditions=react-server`.

This guards against the failure mode that broke lucide-react v1 (lucide-icons/lucide#4200): a module-level `createContext()` made every icon unimportable in a Server Component, and a `"use client"` directive did not help because bundlers drop directives when pre-bundling a dependency. Verified to go red when that pattern is injected.

It covers **both** published entries. The package has no `exports` map, so Node resolves the bare specifier to `main` (CJS) while bundlers follow `module` (ESM) — and it is the bundler path that feeds the RSC graph. The first version of this test only checked the bare specifier and let an injected regression through.

The test runs against a sandboxed copy of the built package: in the workspace the package is a symlink, so `react` resolves to the catalog's React 18, which has no usable react-server build.

**`keyof ReactSVG` replaced with a self-contained `SvgElementName` union** in `@tabler/icons-react` and `@tabler/icons-react-native`. It reproduces `ReactSVG`'s 55 keys exactly, so the type is unchanged for consumers — nothing that type-checked before stops doing so — and it no longer depends on a React type that comes and goes between majors.

## Verified

`turbo run test --filter=!@tabler/icons-angular` — 31 tasks, all passing. The type matrix is clean on 16.14, 17.0, 18.3 and 19.2. The RSC guard is 7/7.

## Open

Narrowing `SvgElementName` to the tags the generator actually emits — only `path` today — would be a better type, but it is a breaking change and belongs in 4.0.