### PR TITLE
Load the sponsors image from GitHub instead of jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 **If you want to support our project and help me grow it, you can [become a sponsor on GitHub](https://github.com/sponsors/codecalm) or just [donate on PayPal](https://paypal.me/codecalm) :)**
 
 <a href="https://github.com/sponsors/codecalm">
-  <img src="https://cdn.jsdelivr.net/gh/tabler/sponsors@latest/sponsors.svg" alt="Tabler sponsors">
+  <img src="https://raw.githubusercontent.com/tabler/sponsors/main/sponsors.svg" alt="Tabler sponsors">
 </a>
 
 ## Preview


### PR DESCRIPTION
## Summary

- The sponsors banner in the README now loads from `raw.githubusercontent.com/tabler/sponsors/main/sponsors.svg` instead of the jsDelivr mirror.
- jsDelivr's `@latest` tag pins to the last tagged release of `tabler/sponsors` and caches it, so new sponsors could take a long time to show up. The raw URL always serves the current file from the default branch.
- GitHub serves the file as `image/svg+xml`, so it still renders inside `<img>`.

**How to review:** open the README on this branch and check that the sponsors image loads.
